### PR TITLE
Remove default bound from ringbuffer trait using MaybeUninit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use with_generic_array::GenericRingBuffer;
 
 /// Used internally. Computes the bitmask used to properly wrap the ringbuffers.
 #[inline]
-fn mask<T: Default + 'static>(this: &impl RingBuffer<T>, index: usize) -> usize {
+fn mask<T: 'static>(this: &impl RingBuffer<T>, index: usize) -> usize {
     index & (this.capacity() - 1)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -936,4 +936,59 @@ mod tests {
         #[cfg(feature = "const_generics")]
         test_push_pop_push_full_get_rep(ConstGenericRingBuffer::<i32, 8>::new());
     }
+
+    mod test_dropping {
+        use super::*;
+        use std::boxed::Box;
+        use std::cell::{RefCell, RefMut};
+
+        struct DropTest {
+            flag: bool,
+        }
+
+        struct Dropee<'a> {
+            parent: Option<RefMut<'a, DropTest>>,
+        }
+
+        impl<'a> Drop for Dropee<'a> {
+            fn drop(&mut self) {
+                if let Some(parent) = &mut self.parent {
+                    parent.flag = true;
+                }
+            }
+        }
+
+        macro_rules! test_dropped {
+            ($constructor: block) => {
+                {
+                    let dt = Box::leak(Box::new(RefCell::new(DropTest { flag: false })));
+                    {
+                        let d = Dropee { parent: Some(dt.borrow_mut()) };
+                        let mut rb = { $constructor };
+                        rb.push(d);
+                        rb.push(Dropee { parent: None });
+                    }
+                    assert!(dt.borrow_mut().flag);
+                    unsafe {
+                        // SAFETY: we know Dropee, which needed the static lifetime, has been dropped (by the assert)
+                        // we could probably skip this, but this makes sure we don't leak any memory
+                        let ptr: *mut RefCell<DropTest> = std::mem::transmute::<&RefCell<DropTest>, _>(dt);
+                        drop(Box::from_raw(ptr));
+                    }
+                }
+            };
+        }
+
+        #[test]
+        fn run_test_drops_contents_generic() {
+            test_dropped!({ GenericRingBuffer::<_, typenum::U1>::new() });
+        }
+
+        
+        #[cfg(feature = "const_generics")]
+        #[test]
+        fn run_test_drops_contents_const_generic() {
+            test_dropped!({ ConstGenericRingBuffer::<_, 1>::new() });
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -980,11 +980,15 @@ mod tests {
         }
 
         #[test]
+        fn run_test_drops_contents_alloc() {
+            test_dropped!({ AllocRingBuffer::with_capacity(1) });
+        }
+
+        #[test]
         fn run_test_drops_contents_generic() {
             test_dropped!({ GenericRingBuffer::<_, typenum::U1>::new() });
         }
 
-        
         #[cfg(feature = "const_generics")]
         #[test]
         fn run_test_drops_contents_const_generic() {

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -229,7 +229,7 @@ pub use iter::{RingBufferIterator, RingBufferMutIterator};
 /// Implement the get, get_mut, get_absolute and get_absolute_mut functions on implementors
 /// of RingBuffer. This is to avoid duplicate code.
 macro_rules! impl_ringbuffer {
-    ($readptr: ident, $writeptr: ident, $mask: expr) => {
+    ($get_unchecked: ident, $get_unchecked_mut: ident, $readptr: ident, $writeptr: ident, $mask: expr) => {
         #[inline]
         fn get(&self, index: isize) -> Option<&T> {
             if !self.is_empty() {
@@ -238,7 +238,7 @@ macro_rules! impl_ringbuffer {
                 unsafe {
                     // SAFETY: index has been modulo-ed and offset from readptr
                     // to be within bounds
-                    Some(self.get_unchecked(index))
+                    Some(self.$get_unchecked(index))
                 }
             } else {
                 None
@@ -253,7 +253,7 @@ macro_rules! impl_ringbuffer {
                 unsafe {
                     // SAFETY: index has been modulo-ed and offset from readptr
                     // to be within bounds
-                    Some(self.get_unchecked_mut(index))
+                    Some(self.$get_unchecked_mut(index))
                 }
             } else {
                 None
@@ -267,7 +267,7 @@ macro_rules! impl_ringbuffer {
             if index >= read && index < write {
                 unsafe {
                     // SAFETY: index has been checked against $mask to be within bounds
-                    Some(self.get_unchecked(index))
+                    Some(self.$get_unchecked(index))
                 }
             } else {
                 None
@@ -279,7 +279,7 @@ macro_rules! impl_ringbuffer {
             if index >= $mask(self, self.$readptr) && index < $mask(self, self.$writeptr) {
                 unsafe {
                     // SAFETY: index has been checked against $mask to be within bounds
-                    Some(self.get_unchecked_mut(index))
+                    Some(self.$get_unchecked_mut(index))
                 }
             } else {
                 None

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -12,7 +12,7 @@ use core::iter::FromIterator;
 ///
 /// This trait is not object safe, so can't be used dynamically. However it is possible to
 /// define a generic function over types implementing RingBuffer.
-pub trait RingBuffer<T: 'static + Default>:
+pub trait RingBuffer<T: 'static>:
     Default + Index<isize, Output = T> + IndexMut<isize> + FromIterator<T>
 {
     /// Returns the length of the internal buffer.
@@ -158,13 +158,13 @@ mod iter {
 
     /// RingBufferIterator holds a reference to a RingBuffer and iterates over it. `index` is the
     /// current iterator position.
-    pub struct RingBufferIterator<'rb, T: 'static + Default, RB: RingBuffer<T>> {
+    pub struct RingBufferIterator<'rb, T: 'static, RB: RingBuffer<T>> {
         obj: &'rb RB,
         index: usize,
         phantom: PhantomData<T>,
     }
 
-    impl<'rb, T: 'static + Default, RB: RingBuffer<T>> RingBufferIterator<'rb, T, RB> {
+    impl<'rb, T: 'static, RB: RingBuffer<T>> RingBufferIterator<'rb, T, RB> {
         #[inline]
         pub fn new(obj: &'rb RB) -> Self {
             Self {
@@ -175,7 +175,7 @@ mod iter {
         }
     }
 
-    impl<'rb, T: 'static + Default, RB: RingBuffer<T>> Iterator for RingBufferIterator<'rb, T, RB> {
+    impl<'rb, T: 'static, RB: RingBuffer<T>> Iterator for RingBufferIterator<'rb, T, RB> {
         type Item = &'rb T;
 
         #[inline]
@@ -195,13 +195,13 @@ mod iter {
     ///
     /// WARNING: NEVER ACCESS THE `obj` FIELD. it's private on purpose, and can technically be accessed
     /// in the same module. However, this breaks the safety of `next()`
-    pub struct RingBufferMutIterator<'rb, T: 'static + Default, RB: RingBuffer<T>> {
+    pub struct RingBufferMutIterator<'rb, T: 'static, RB: RingBuffer<T>> {
         obj: &'rb mut RB,
         index: usize,
         phantom: PhantomData<T>,
     }
 
-    impl<'rb, T: 'static + Default, RB: RingBuffer<T>> RingBufferMutIterator<'rb, T, RB> {
+    impl<'rb, T: 'static, RB: RingBuffer<T>> RingBufferMutIterator<'rb, T, RB> {
         #[inline]
         pub fn new(obj: &'rb mut RB) -> Self {
             Self {
@@ -229,13 +229,17 @@ pub use iter::{RingBufferIterator, RingBufferMutIterator};
 /// Implement the get, get_mut, get_absolute and get_absolute_mut functions on implementors
 /// of RingBuffer. This is to avoid duplicate code.
 macro_rules! impl_ringbuffer {
-    ($buf: ident, $readptr: ident, $writeptr: ident, $mask: expr) => {
+    ($readptr: ident, $writeptr: ident, $mask: expr) => {
         #[inline]
         fn get(&self, index: isize) -> Option<&T> {
             if !self.is_empty() {
                 let index = (self.$readptr as isize + index) as usize % self.len();
 
-                self.$buf.get(index)
+                unsafe {
+                    // SAFETY: index has been modulo-ed and offset from readptr
+                    // to be within bounds
+                    Some(self.get_unchecked(index))
+                }
             } else {
                 None
             }
@@ -246,7 +250,11 @@ macro_rules! impl_ringbuffer {
             if !self.is_empty() {
                 let index = (self.$readptr as isize + index) as usize % self.len();
 
-                self.$buf.get_mut(index)
+                unsafe {
+                    // SAFETY: index has been modulo-ed and offset from readptr
+                    // to be within bounds
+                    Some(self.get_unchecked_mut(index))
+                }
             } else {
                 None
             }
@@ -257,7 +265,10 @@ macro_rules! impl_ringbuffer {
             let read = $mask(self, self.$readptr);
             let write = $mask(self, self.$writeptr);
             if index >= read && index < write {
-                self.$buf.get(index)
+                unsafe {
+                    // SAFETY: index has been checked against $mask to be within bounds
+                    Some(self.get_unchecked(index))
+                }
             } else {
                 None
             }
@@ -266,7 +277,10 @@ macro_rules! impl_ringbuffer {
         #[inline]
         fn get_absolute_mut(&mut self, index: usize) -> Option<&mut T> {
             if index >= $mask(self, self.$readptr) && index < $mask(self, self.$writeptr) {
-                self.$buf.get_mut(index)
+                unsafe {
+                    // SAFETY: index has been checked against $mask to be within bounds
+                    Some(self.get_unchecked_mut(index))
+                }
             } else {
                 None
             }

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -45,7 +45,7 @@ pub struct AllocRingBuffer<T> {
 // must be a power of 2
 pub const RINGBUFFER_DEFAULT_CAPACITY: usize = 1024;
 
-impl<T: 'static + Default> RingBuffer<T> for AllocRingBuffer<T> {
+impl<T: 'static> RingBuffer<T> for AllocRingBuffer<T> {
     #[inline]
     fn capacity(&self) -> usize {
         self.capacity
@@ -81,7 +81,7 @@ impl<T: 'static + Default> RingBuffer<T> for AllocRingBuffer<T> {
         }
     }
 
-    impl_ringbuffer!(buf, readptr, writeptr, crate::mask);
+    impl_ringbuffer!(readptr, writeptr, crate::mask);
 }
 
 impl<T> AllocRingBuffer<T> {
@@ -118,9 +118,23 @@ impl<T> AllocRingBuffer<T> {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Get a reference from the buffer without checking it is initialized.
+    /// Caller must be sure the index is in bounds, or this will panic.
+    /// However, it's not unsafe -- only unsafe to match signature of other methods.
+    unsafe fn get_unchecked(&self, index: usize) -> &T {
+        &self.buf[index]
+    }
+
+    /// Get a mut reference from the buffer without checking it is initialized.
+    /// Caller must be sure the index is in bounds, or this will panic.
+    /// However, it's not unsafe -- only unsafe to match signature of other methods.
+    unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
+        &mut self.buf[index]
+    }
 }
 
-impl<RB: 'static + Default> FromIterator<RB> for AllocRingBuffer<RB> {
+impl<RB: 'static> FromIterator<RB> for AllocRingBuffer<RB> {
     fn from_iter<T: IntoIterator<Item = RB>>(iter: T) -> Self {
         let mut res = Self::default();
         for i in iter {
@@ -145,7 +159,7 @@ impl<T> Default for AllocRingBuffer<T> {
     }
 }
 
-impl<T: 'static + Default> Index<isize> for AllocRingBuffer<T> {
+impl<T: 'static> Index<isize> for AllocRingBuffer<T> {
     type Output = T;
 
     fn index(&self, index: isize) -> &Self::Output {
@@ -153,7 +167,7 @@ impl<T: 'static + Default> Index<isize> for AllocRingBuffer<T> {
     }
 }
 
-impl<T: 'static + Default> IndexMut<isize> for AllocRingBuffer<T> {
+impl<T: 'static> IndexMut<isize> for AllocRingBuffer<T> {
     fn index_mut(&mut self, index: isize) -> &mut Self::Output {
         self.get_mut(index).expect("index out of bounds")
     }

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -81,7 +81,7 @@ impl<T: 'static> RingBuffer<T> for AllocRingBuffer<T> {
         }
     }
 
-    impl_ringbuffer!(readptr, writeptr, crate::mask);
+    impl_ringbuffer!(get_unchecked, get_unchecked_mut, readptr, writeptr, crate::mask);
 }
 
 impl<T> AllocRingBuffer<T> {

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -1,5 +1,6 @@
 use crate::RingBuffer;
 use core::iter::FromIterator;
+use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
 
 /// The ConstGenericRingBuffer struct is a RingBuffer implementation which does not require `alloc`.
@@ -31,17 +32,32 @@ use core::ops::{Index, IndexMut};
 /// buffer.push(1);
 /// assert_eq!(buffer.to_vec(), vec![42, 1]);
 /// ```
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Debug)]
 pub struct ConstGenericRingBuffer<T, const CAP: usize> {
-    buf: [T; CAP],
+    buf: [MaybeUninit<T>; CAP],
     readptr: usize,
     writeptr: usize,
 }
 
-/// It is only possible to create a Generic RingBuffer if the type T in it implements Default.
-/// This is because the array needs to be allocated at compile time, and needs to be filled with
-/// some default value.
-impl<T: Default, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
+// We need to manually implement PartialEq because MaybeUninit isn't PartialEq
+impl<T: 'static + PartialEq, const CAP: usize> PartialEq for ConstGenericRingBuffer<T, CAP> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            false
+        } else {
+            for (a, b) in self.iter().zip(other.iter()) {
+                if a != b {
+                    return false;
+                }
+            }
+            true
+        }
+    }
+}
+
+impl<T: 'static + PartialEq, const CAP: usize> Eq for ConstGenericRingBuffer<T, CAP> {}
+
+impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     /// Creates a new RingBuffer. The method is here for compatibility with the alloc version of
     /// RingBuffer. This method simply creates a default ringbuffer. The capacity is given as a
     /// type parameter.
@@ -49,9 +65,27 @@ impl<T: Default, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Get a reference from the buffer without checking it is initialized
+    /// Caller MUST be sure this index is initialized, or undefined behavior will happen
+    unsafe fn get_unchecked(&self, index: usize) -> &T {
+        self.buf[index]
+            .as_ptr()
+            .as_ref()
+            .expect("const array ptr shouldn't be null!")
+    }
+
+    /// Get a mutable reference from the buffer without checking it is initialized
+    /// Caller MUST be sure this index is initialized, or undefined behavior will happen
+    unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
+        self.buf[index]
+            .as_mut_ptr()
+            .as_mut()
+            .expect("const array ptr shouldn't be null!")
+    }
 }
 
-impl<T: 'static + Default, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP> {
+impl<T: 'static, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP> {
     #[inline]
     #[cfg(not(tarpaulin_include))]
     fn capacity(&self) -> usize {
@@ -64,7 +98,7 @@ impl<T: 'static + Default, const CAP: usize> RingBuffer<T> for ConstGenericRingB
             self.readptr += 1;
         }
         let index = crate::mask(self, self.writeptr);
-        self.buf[index] = value;
+        self.buf[index] = MaybeUninit::new(value);
         self.writeptr += 1;
     }
 
@@ -72,7 +106,13 @@ impl<T: 'static + Default, const CAP: usize> RingBuffer<T> for ConstGenericRingB
     fn dequeue_ref(&mut self) -> Option<&T> {
         if !self.is_empty() {
             let index = crate::mask(self, self.readptr);
-            let res = &self.buf[index];
+            let res = unsafe {
+                // SAFETY: index has been masked
+                self.buf[index]
+                    .as_ptr()
+                    .as_ref()
+                    .expect("const array ptr shouldn't be null!")
+            };
             self.readptr += 1;
 
             Some(res)
@@ -81,17 +121,17 @@ impl<T: 'static + Default, const CAP: usize> RingBuffer<T> for ConstGenericRingB
         }
     }
 
-    impl_ringbuffer!(buf, readptr, writeptr, crate::mask);
+    impl_ringbuffer!(readptr, writeptr, crate::mask);
 }
 
-impl<T: Default, const CAP: usize> Default for ConstGenericRingBuffer<T, CAP> {
+impl<T, const CAP: usize> Default for ConstGenericRingBuffer<T, CAP> {
     /// Creates a buffer with a capacity specified through the Cap type parameter.
     #[inline]
     fn default() -> Self {
         assert_ne!(CAP, 0, "Capacity must be greater than 0");
         assert!(CAP.is_power_of_two(), "Capacity must be a power of two");
 
-        let arr = array_init::array_init(|_| T::default());
+        let arr = array_init::array_init(|_| MaybeUninit::uninit());
 
         Self {
             buf: arr,
@@ -101,7 +141,7 @@ impl<T: Default, const CAP: usize> Default for ConstGenericRingBuffer<T, CAP> {
     }
 }
 
-impl<RB: 'static + Default, const CAP: usize> FromIterator<RB> for ConstGenericRingBuffer<RB, CAP> {
+impl<RB: 'static, const CAP: usize> FromIterator<RB> for ConstGenericRingBuffer<RB, CAP> {
     fn from_iter<T: IntoIterator<Item = RB>>(iter: T) -> Self {
         let mut res = Self::default();
         for i in iter {
@@ -112,7 +152,7 @@ impl<RB: 'static + Default, const CAP: usize> FromIterator<RB> for ConstGenericR
     }
 }
 
-impl<T: 'static + Default, const CAP: usize> Index<isize> for ConstGenericRingBuffer<T, CAP> {
+impl<T: 'static, const CAP: usize> Index<isize> for ConstGenericRingBuffer<T, CAP> {
     type Output = T;
 
     fn index(&self, index: isize) -> &Self::Output {
@@ -120,7 +160,7 @@ impl<T: 'static + Default, const CAP: usize> Index<isize> for ConstGenericRingBu
     }
 }
 
-impl<T: 'static + Default, const CAP: usize> IndexMut<isize> for ConstGenericRingBuffer<T, CAP> {
+impl<T: 'static, const CAP: usize> IndexMut<isize> for ConstGenericRingBuffer<T, CAP> {
     fn index_mut(&mut self, index: isize) -> &mut Self::Output {
         self.get_mut(index).expect("index out of bounds")
     }

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -106,14 +106,11 @@ impl<T: 'static, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, C
     fn dequeue_ref(&mut self) -> Option<&T> {
         if !self.is_empty() {
             let index = crate::mask(self, self.readptr);
+            self.readptr += 1;
             let res = unsafe {
                 // SAFETY: index has been masked
-                self.buf[index]
-                    .as_ptr()
-                    .as_ref()
-                    .expect("const array ptr shouldn't be null!")
+                self.get_unchecked(index)
             };
-            self.readptr += 1;
 
             Some(res)
         } else {

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -126,7 +126,7 @@ impl<T: 'static, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, C
         }
     }
 
-    impl_ringbuffer!(readptr, writeptr, crate::mask);
+    impl_ringbuffer!(get_unchecked, get_unchecked_mut, readptr, writeptr, crate::mask);
 }
 
 impl<T, const CAP: usize> Default for ConstGenericRingBuffer<T, CAP> {

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -95,11 +95,11 @@ impl<T: 'static, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, C
     #[inline]
     fn push(&mut self, value: T) {
         if self.is_full() {
+            let index = crate::mask(self, self.readptr);
             unsafe {
                 // make sure we drop whatever is being overwritten
                 // SAFETY: the buffer is full, so this must be inited
                 //       : also, index has been masked
-                let index = crate::mask(self, self.readptr);
                 // make sure we drop because it won't happen automatically
                 core::ptr::drop_in_place(self.buf[index].as_mut_ptr());
             }

--- a/src/with_generic_array.rs
+++ b/src/with_generic_array.rs
@@ -149,11 +149,11 @@ impl<T: 'static, Cap: ArrayLength<MaybeUninit<T>>> RingBuffer<T> for GenericRing
     #[inline]
     fn push(&mut self, value: T) {
         if self.is_full() {
+            let index = crate::mask(self, self.readptr);
             unsafe {
                 // make sure we drop whatever is being overwritten
                 // SAFETY: the buffer is full, so this must be inited
                 //       : also, index has been masked
-                let index = crate::mask(self, self.readptr);
                 // make sure we drop because it won't happen automatically
                 core::ptr::drop_in_place(self.buf[index].as_mut_ptr());
             }

--- a/src/with_generic_array.rs
+++ b/src/with_generic_array.rs
@@ -179,7 +179,7 @@ impl<T: 'static, Cap: ArrayLength<MaybeUninit<T>>> RingBuffer<T> for GenericRing
         }
     }
 
-    impl_ringbuffer!(readptr, writeptr, crate::mask);
+    impl_ringbuffer!(get_unchecked, get_unchecked_mut, readptr, writeptr, crate::mask);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #13

Use MaybeUninit in `ConstGenericRingBuffer` / `GenericRingBuffer`. Adds new unsafe methods `get_unchecked` / `get_unchecked_mut`, and refactors the `impl_ringbuffer!` macro to use those methods instead of directly accessing the buffer, so we can munge the `MaybeUninit` for the impls that need it. These methods should maybe be part of the `Ringbuffer` trait? Right now they're non-exported impls that the macro can call by virtue of defining methods in the struct anyways.