### PR TITLE
Move to min_const_generics

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
         override: true
 
     - name: rust-tarpaulin
-      uses: actions-rs/tarpaulin@v0.1.0
+      uses: actions-rs/tarpaulin@v0.1.3
       with:
         args: --all-features --out Xml
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ lto = true
 
 [dependencies]
 generic-array = {version = "0.14.4", optional=true}
-array-init = {git = "https://github.com/manishearth/array-init", version = "0.1.1", optional=true}
+array-init = { version = "1.0.0", optional=true}
 
 [dev-dependencies]
 criterion = "0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
-#![cfg_attr(feature = "const_generics", feature(const_generics))]
-#![cfg_attr(feature = "const_generics", allow(incomplete_features))]
+#![cfg_attr(feature = "const_generics", feature(min_const_generics))]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![deny(unused_import_braces)]


### PR DESCRIPTION
As `min_const_generics` is getting stabilized [[1]]
and we only need that subset we should move to it for compatability reasons


[1]: https://github.com/rust-lang/rust/pull/79135