### PR TITLE
Remove 'static lifetime requirements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,30 @@ mod tests {
         test_iter(GenericRingBuffer::<i32, typenum::U8>::new());
     }
 
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn run_test_iter_with_lifetimes() {
+        fn test_iter<'a>(string: &'a str, mut b: impl RingBuffer<&'a str>) {
+            b.push(&string[0..1]);
+            b.push(&string[1..2]);
+            b.push(&string[2..3]);
+
+            let mut iter = b.iter();
+            assert_eq!(&&string[0..1], iter.next().unwrap());
+            assert_eq!(&&string[1..2], iter.next().unwrap());
+            assert_eq!(&&string[2..3], iter.next().unwrap());
+        }
+
+        extern crate alloc;
+        use alloc::string::ToString as _;
+        let string = "abc".to_string();
+
+        test_iter(&string, AllocRingBuffer::with_capacity(8));
+        #[cfg(feature = "const_generics")]
+        test_iter(&string, ConstGenericRingBuffer::<&str, 8>::new());
+        test_iter(&string, GenericRingBuffer::<&str, typenum::U8>::new());
+    }
+
     #[test]
     fn run_test_double_iter() {
         fn test_double_iter(mut b: impl RingBuffer<i32>) {

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -11,9 +11,7 @@ use core::iter::FromIterator;
 ///
 /// This trait is not object safe, so can't be used dynamically. However it is possible to
 /// define a generic function over types implementing RingBuffer.
-pub trait RingBuffer<T: 'static>:
-    Index<isize, Output = T> + IndexMut<isize> + FromIterator<T>
-{
+pub trait RingBuffer<T>: Index<isize, Output = T> + IndexMut<isize> + FromIterator<T> {
     /// Returns the length of the internal buffer.
     /// This length grows up to the capacity and then stops growing.
     /// This is because when the length is reached, new items are appended at the start.
@@ -152,13 +150,13 @@ mod iter {
 
     /// RingBufferIterator holds a reference to a RingBuffer and iterates over it. `index` is the
     /// current iterator position.
-    pub struct RingBufferIterator<'rb, T: 'static, RB: RingBuffer<T>> {
+    pub struct RingBufferIterator<'rb, T, RB: RingBuffer<T>> {
         obj: &'rb RB,
         index: usize,
         phantom: PhantomData<T>,
     }
 
-    impl<'rb, T: 'static, RB: RingBuffer<T>> RingBufferIterator<'rb, T, RB> {
+    impl<'rb, T, RB: RingBuffer<T>> RingBufferIterator<'rb, T, RB> {
         #[inline]
         pub fn new(obj: &'rb RB) -> Self {
             Self {
@@ -169,7 +167,7 @@ mod iter {
         }
     }
 
-    impl<'rb, T: 'static, RB: RingBuffer<T>> Iterator for RingBufferIterator<'rb, T, RB> {
+    impl<'rb, T: 'rb, RB: RingBuffer<T>> Iterator for RingBufferIterator<'rb, T, RB> {
         type Item = &'rb T;
 
         #[inline]
@@ -189,13 +187,13 @@ mod iter {
     ///
     /// WARNING: NEVER ACCESS THE `obj` FIELD. it's private on purpose, and can technically be accessed
     /// in the same module. However, this breaks the safety of `next()`
-    pub struct RingBufferMutIterator<'rb, T: 'static, RB: RingBuffer<T>> {
+    pub struct RingBufferMutIterator<'rb, T, RB: RingBuffer<T>> {
         obj: &'rb mut RB,
         index: usize,
         phantom: PhantomData<T>,
     }
 
-    impl<'rb, T: 'static, RB: RingBuffer<T>> RingBufferMutIterator<'rb, T, RB> {
+    impl<'rb, T, RB: RingBuffer<T>> RingBufferMutIterator<'rb, T, RB> {
         #[inline]
         pub fn new(obj: &'rb mut RB) -> Self {
             Self {

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -45,7 +45,7 @@ pub struct AllocRingBuffer<T> {
 // must be a power of 2
 pub const RINGBUFFER_DEFAULT_CAPACITY: usize = 1024;
 
-impl<T: 'static> RingBuffer<T> for AllocRingBuffer<T> {
+impl<T> RingBuffer<T> for AllocRingBuffer<T> {
     #[inline]
     fn capacity(&self) -> usize {
         self.capacity
@@ -142,7 +142,7 @@ impl<T> AllocRingBuffer<T> {
     }
 }
 
-impl<RB: 'static> FromIterator<RB> for AllocRingBuffer<RB> {
+impl<RB> FromIterator<RB> for AllocRingBuffer<RB> {
     fn from_iter<T: IntoIterator<Item = RB>>(iter: T) -> Self {
         let mut res = Self::default();
         for i in iter {
@@ -166,7 +166,7 @@ impl<T> Default for AllocRingBuffer<T> {
     }
 }
 
-impl<T: 'static> Index<isize> for AllocRingBuffer<T> {
+impl<T> Index<isize> for AllocRingBuffer<T> {
     type Output = T;
 
     fn index(&self, index: isize) -> &Self::Output {
@@ -174,7 +174,7 @@ impl<T: 'static> Index<isize> for AllocRingBuffer<T> {
     }
 }
 
-impl<T: 'static> IndexMut<isize> for AllocRingBuffer<T> {
+impl<T> IndexMut<isize> for AllocRingBuffer<T> {
     fn index_mut(&mut self, index: isize) -> &mut Self::Output {
         self.get_mut(index).expect("index out of bounds")
     }

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -39,7 +39,7 @@ pub struct ConstGenericRingBuffer<T, const CAP: usize> {
     writeptr: usize,
 }
 
-impl<T: 'static + Clone, const CAP: usize> Clone for ConstGenericRingBuffer<T, CAP> {
+impl<T: Clone, const CAP: usize> Clone for ConstGenericRingBuffer<T, CAP> {
     fn clone(&self) -> Self {
         let mut new = ConstGenericRingBuffer::<T, CAP>::new();
         for elem in self.iter() {
@@ -50,7 +50,7 @@ impl<T: 'static + Clone, const CAP: usize> Clone for ConstGenericRingBuffer<T, C
 }
 
 // We need to manually implement PartialEq because MaybeUninit isn't PartialEq
-impl<T: 'static + PartialEq, const CAP: usize> PartialEq for ConstGenericRingBuffer<T, CAP> {
+impl<T: PartialEq, const CAP: usize> PartialEq for ConstGenericRingBuffer<T, CAP> {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
             false
@@ -65,7 +65,7 @@ impl<T: 'static + PartialEq, const CAP: usize> PartialEq for ConstGenericRingBuf
     }
 }
 
-impl<T: 'static + PartialEq, const CAP: usize> Eq for ConstGenericRingBuffer<T, CAP> {}
+impl<T: PartialEq, const CAP: usize> Eq for ConstGenericRingBuffer<T, CAP> {}
 
 impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     /// Creates a new RingBuffer. This method simply creates a default ringbuffer. The capacity is given as a
@@ -94,7 +94,7 @@ impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     }
 }
 
-impl<T: 'static, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP> {
+impl<T, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP> {
     #[inline]
     #[cfg(not(tarpaulin_include))]
     fn capacity(&self) -> usize {
@@ -161,7 +161,7 @@ impl<T, const CAP: usize> Default for ConstGenericRingBuffer<T, CAP> {
     }
 }
 
-impl<RB: 'static, const CAP: usize> FromIterator<RB> for ConstGenericRingBuffer<RB, CAP> {
+impl<RB, const CAP: usize> FromIterator<RB> for ConstGenericRingBuffer<RB, CAP> {
     fn from_iter<T: IntoIterator<Item = RB>>(iter: T) -> Self {
         let mut res = Self::default();
         for i in iter {
@@ -172,7 +172,7 @@ impl<RB: 'static, const CAP: usize> FromIterator<RB> for ConstGenericRingBuffer<
     }
 }
 
-impl<T: 'static, const CAP: usize> Index<isize> for ConstGenericRingBuffer<T, CAP> {
+impl<T, const CAP: usize> Index<isize> for ConstGenericRingBuffer<T, CAP> {
     type Output = T;
 
     fn index(&self, index: isize) -> &Self::Output {
@@ -180,7 +180,7 @@ impl<T: 'static, const CAP: usize> Index<isize> for ConstGenericRingBuffer<T, CA
     }
 }
 
-impl<T: 'static, const CAP: usize> IndexMut<isize> for ConstGenericRingBuffer<T, CAP> {
+impl<T, const CAP: usize> IndexMut<isize> for ConstGenericRingBuffer<T, CAP> {
     fn index_mut(&mut self, index: isize) -> &mut Self::Output {
         self.get_mut(index).expect("index out of bounds")
     }

--- a/src/with_generic_array.rs
+++ b/src/with_generic_array.rs
@@ -45,9 +45,7 @@ pub struct GenericRingBuffer<T, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> {
     writeptr: usize,
 }
 
-impl<T: 'static + Clone, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Clone
-    for GenericRingBuffer<T, Cap>
-{
+impl<T: Clone, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Clone for GenericRingBuffer<T, Cap> {
     fn clone(&self) -> Self {
         let mut new = GenericRingBuffer::<T, Cap>::new();
         for elem in self.iter() {
@@ -58,7 +56,7 @@ impl<T: 'static + Clone, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Clone
 }
 
 // We need to manually implement PartialEq because MaybeUninit isn't PartialEq
-impl<T: 'static + PartialEq, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> PartialEq
+impl<T: PartialEq, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> PartialEq
     for GenericRingBuffer<T, Cap>
 {
     fn eq(&self, other: &Self) -> bool {
@@ -75,10 +73,7 @@ impl<T: 'static + PartialEq, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Part
     }
 }
 
-impl<T: 'static + PartialEq, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Eq
-    for GenericRingBuffer<T, Cap>
-{
-}
+impl<T: PartialEq, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Eq for GenericRingBuffer<T, Cap> {}
 
 impl<T, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> GenericRingBuffer<T, Cap> {
     /// Creates a new RingBuffer. The method is here for compatibility with the alloc version of
@@ -125,7 +120,7 @@ impl<T, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Default for GenericRingBu
     }
 }
 
-impl<RB: 'static, Cap: PowerOfTwo + ArrayLength<MaybeUninit<RB>>> FromIterator<RB>
+impl<RB, Cap: PowerOfTwo + ArrayLength<MaybeUninit<RB>>> FromIterator<RB>
     for GenericRingBuffer<RB, Cap>
 {
     fn from_iter<T: IntoIterator<Item = RB>>(iter: T) -> Self {
@@ -138,9 +133,7 @@ impl<RB: 'static, Cap: PowerOfTwo + ArrayLength<MaybeUninit<RB>>> FromIterator<R
     }
 }
 
-impl<T: 'static, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Index<isize>
-    for GenericRingBuffer<T, Cap>
-{
+impl<T, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Index<isize> for GenericRingBuffer<T, Cap> {
     type Output = T;
 
     fn index(&self, index: isize) -> &Self::Output {
@@ -148,7 +141,7 @@ impl<T: 'static, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> Index<isize>
     }
 }
 
-impl<T: 'static, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> IndexMut<isize>
+impl<T, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> IndexMut<isize>
     for GenericRingBuffer<T, Cap>
 {
     fn index_mut(&mut self, index: isize) -> &mut Self::Output {
@@ -156,9 +149,7 @@ impl<T: 'static, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> IndexMut<isize>
     }
 }
 
-impl<T: 'static, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> RingBuffer<T>
-    for GenericRingBuffer<T, Cap>
-{
+impl<T, Cap: PowerOfTwo + ArrayLength<MaybeUninit<T>>> RingBuffer<T> for GenericRingBuffer<T, Cap> {
     #[inline(always)]
     #[cfg(not(tarpaulin_include))]
     fn capacity(&self) -> usize {


### PR DESCRIPTION
I wanted to use this ringbuffer crate to store a bunch of `&str` into a `String` but quickly ran into the issue that `T: 'static` everywhere throughout the crate.

From a quick look I didn't see where `'static` would be a hard requirement, and so I went and mostly removed it. Existing tests and a somewhat artificial test I created seem to pass.