### PR TITLE
Implement additional iterator traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,11 +196,14 @@ mod tests {
             b.push(1);
             b.push(2);
             b.push(3);
+            b.push(4);
 
             let mut iter = b.iter();
             assert_eq!(&1, iter.next().unwrap());
+            assert_eq!(&4, iter.next_back().unwrap());
             assert_eq!(&2, iter.next().unwrap());
             assert_eq!(&3, iter.next().unwrap());
+            assert_eq!(None, iter.next());
         }
 
         test_iter(AllocRingBuffer::with_capacity(8));

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -202,6 +202,7 @@ mod iter {
     /// current iterator position.
     pub struct RingBufferIterator<'rb, T, RB: RingBufferExt<T>> {
         obj: &'rb RB,
+        len: usize,
         index: usize,
         phantom: PhantomData<T>,
     }
@@ -211,6 +212,7 @@ mod iter {
         pub fn new(obj: &'rb RB) -> Self {
             Self {
                 obj,
+                len: obj.len(),
                 index: 0,
                 phantom: PhantomData::default(),
             }
@@ -222,9 +224,22 @@ mod iter {
 
         #[inline]
         fn next(&mut self) -> Option<Self::Item> {
-            if self.index < self.obj.len() {
+            if self.index < self.len {
                 let res = self.obj.get(self.index as isize);
                 self.index += 1;
+                res
+            } else {
+                None
+            }
+        }
+    }
+
+    impl<'rb, T: 'rb, RB: RingBufferExt<T>> DoubleEndedIterator for RingBufferIterator<'rb, T, RB> {
+        #[inline]
+        fn next_back(&mut self) -> Option<Self::Item> {
+            if self.len > 0 && self.index < self.len {
+                let res = self.obj.get((self.len - 1) as isize);
+                self.len -= 1;
                 res
             } else {
                 None

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -232,6 +232,10 @@ mod iter {
                 None
             }
         }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (self.len, Some(self.len))
+        }
     }
 
     impl<'rb, T: 'rb, RB: RingBufferExt<T>> DoubleEndedIterator for RingBufferIterator<'rb, T, RB> {

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -238,6 +238,8 @@ mod iter {
         }
     }
 
+    impl<'rb, T: 'rb, RB: RingBufferExt<T>> core::iter::FusedIterator for RingBufferIterator<'rb, T, RB> { }
+
     impl<'rb, T: 'rb, RB: RingBufferExt<T>> DoubleEndedIterator for RingBufferIterator<'rb, T, RB> {
         #[inline]
         fn next_back(&mut self) -> Option<Self::Item> {

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -197,6 +197,7 @@ pub trait RingBufferExt<T>:
 mod iter {
     use crate::{RingBufferExt, RingBufferRead};
     use core::marker::PhantomData;
+    use core::iter::FusedIterator;
 
     /// RingBufferIterator holds a reference to a `RingBufferExt` and iterates over it. `index` is the
     /// current iterator position.
@@ -238,7 +239,9 @@ mod iter {
         }
     }
 
-    impl<'rb, T: 'rb, RB: RingBufferExt<T>> core::iter::FusedIterator for RingBufferIterator<'rb, T, RB> { }
+    impl<'rb, T: 'rb, RB: RingBufferExt<T>> FusedIterator for RingBufferIterator<'rb, T, RB> { }
+
+    impl<'rb, T: 'rb, RB: RingBufferExt<T>> ExactSizeIterator for RingBufferIterator<'rb, T, RB> { }
 
     impl<'rb, T: 'rb, RB: RingBufferExt<T>> DoubleEndedIterator for RingBufferIterator<'rb, T, RB> {
         #[inline]


### PR DESCRIPTION
For my application I needed a `DoubleEndedIterator` instance. While in town I also added a few other instances which can be safely provided (namely `ExactSizeIterator` and `FusedIterator`).