### PR TITLE
add extend method

### DIFF
--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -41,6 +41,9 @@ pub trait RingBuffer<T>: Sized {
 pub trait RingBufferWrite<T>: RingBuffer<T> {
     /// Pushes a value onto the buffer. Cycles around if capacity is reached.
     fn push(&mut self, value: T);
+
+    /// Pushes a slices of elements to the ring buffer.
+    fn extend(&mut self, values: &[T]) where T: Clone;
 }
 
 /// Defines behaviour for ringbuffers which allow for reading from the start of them (as a queue).

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -131,6 +131,19 @@ impl<T, const CAP: usize> RingBufferWrite<T> for ConstGenericRingBuffer<T, CAP> 
         self.buf[index] = MaybeUninit::new(value);
         self.writeptr += 1;
     }
+
+    #[inline]
+    fn extend(&mut self, values: &[T]) where T: Clone {
+        let skip_n = values.len() as isize - CAP as isize;
+        let skip_n = if skip_n > 0 {
+            // values "too long"
+            skip_n
+        } else {
+            0
+        } as usize;
+        // skip_n is a performance optimization
+        values.iter().skip(skip_n).for_each(|x| self.push(x.clone()))
+    }
 }
 
 impl<T, const CAP: usize> RingBufferExt<T> for ConstGenericRingBuffer<T, CAP> {
@@ -218,5 +231,39 @@ mod tests {
     fn test_index_zero_length() {
         let b = ConstGenericRingBuffer::<i32, 2>::new();
         let _ = b[2];
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut buf = ConstGenericRingBuffer::<u8, 4>::new();
+        (0..4).for_each(|_| buf.push(0));
+
+        let new_data = [0, 1, 2];
+        buf.extend(&new_data);
+
+        let expected = [0, 0, 1, 2];
+
+        for i in 0..4 {
+            let actual = buf[i as isize];
+            let expected = expected[i];
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn test_extend_with_overflow() {
+        let mut buf = ConstGenericRingBuffer::<u8, 8>::new();
+        (0..8).for_each(|_| buf.push(0));
+
+        let new_data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        buf.extend(&new_data);
+
+        let expected = [2, 3, 4, 5, 6, 7, 8, 9];
+
+        for i in 0..8 {
+            let actual = buf[i as isize];
+            let expected = expected[i];
+            assert_eq!(actual, expected);
+        }
     }
 }


### PR DESCRIPTION
Hey @NULLx76 ,
this PR adds an extend-method similar to extend on vectors in the standard library. I hope we can get this merged and released soon. What do you think?

My use case: On each iteration, the sound library gives me ~534 samples. I want to have the latest 2048 samples in a ring buffer and do an FFT on it :)