### PR TITLE
zeroed constructors for numeric buffers

### DIFF
--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -10,6 +10,45 @@ use core::iter::FromIterator;
 use core::mem;
 use core::mem::MaybeUninit;
 
+
+/// Implement various functions on implementors of RingBuffer.
+/// This is to avoid duplicate code.
+macro_rules! impl_numeric_zero_constructor {
+    ($name: ident, $type: ty, $null_ele: expr) => {
+        impl $name<$type> {
+            /// Constructor that initializes the buffer with zeroes.
+            /// This is useful in scenarios, where you expect every
+            /// index of the buffer to be valid from the beginning.
+            /// Wrapper around [`with_capacity`].
+            #[inline]
+            pub fn with_capacity_zeroed(cap: usize) -> Self {
+                let mut obj = Self::with_capacity(cap);
+                for _ in 0..cap {
+                    obj.push($null_ele);
+                }
+                obj
+            }
+        }
+    };
+}
+
+macro_rules! impl_numeric_zero_constructors {
+    ($name: tt) => {
+        impl_numeric_zero_constructor!($name, i8, 0);
+        impl_numeric_zero_constructor!($name, i16, 0);
+        impl_numeric_zero_constructor!($name, i32, 0);
+        impl_numeric_zero_constructor!($name, i64, 0);
+        impl_numeric_zero_constructor!($name, i128, 0);
+        impl_numeric_zero_constructor!($name, u8, 0);
+        impl_numeric_zero_constructor!($name, u16, 0);
+        impl_numeric_zero_constructor!($name, u32, 0);
+        impl_numeric_zero_constructor!($name, u64, 0);
+        impl_numeric_zero_constructor!($name, u128, 0);
+        impl_numeric_zero_constructor!($name, f32, 0.0);
+        impl_numeric_zero_constructor!($name, f64, 0.0);
+    }
+}
+
 /// The `AllocRingBuffer` is a `RingBufferExt` which is based on a Vec. This means it allocates at runtime
 /// on the heap, and therefore needs the [`alloc`] crate. This struct and therefore the dependency on
 /// alloc can be disabled by disabling the `alloc` (default) feature.
@@ -214,6 +253,8 @@ impl<T> AllocRingBuffer<T> {
     }
 }
 
+impl_numeric_zero_constructors!(AllocRingBuffer);
+
 impl<RB> FromIterator<RB> for AllocRingBuffer<RB> {
     fn from_iter<T: IntoIterator<Item = RB>>(iter: T) -> Self {
         let mut res = Self::default();
@@ -334,5 +375,33 @@ mod tests {
             let expected = expected[i];
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn test_zeroed_constructor() {
+        let obj_zeroed = AllocRingBuffer::<i8>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<i16>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<i32>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<i64>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<i128>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<u8>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<u16>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<u32>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<u64>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<u128>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = AllocRingBuffer::<f32>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0.0).count());
+        let obj_zeroed = AllocRingBuffer::<f64>::with_capacity_zeroed(8);
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0.0).count());
     }
 }

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -4,6 +4,45 @@ use core::mem;
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
 
+
+/// Implement various functions on implementors of RingBuffer.
+/// This is to avoid duplicate code.
+macro_rules! impl_numeric_zero_constructor {
+    ($name: ident, $type: ty, $null_ele: expr) => {
+        impl<const CAP: usize> $name<$type, CAP> {
+            /// Constructor that initializes the buffer with zeroes.
+            /// This is useful in scenarios, where you expect every
+            /// index of the buffer to be valid from the beginning.
+            /// Wrapper around [`with_capacity`].
+            #[inline]
+            pub fn new_zeroed() -> Self {
+                let mut obj = Self::new();
+                for _ in 0..CAP {
+                    obj.push($null_ele);
+                }
+                obj
+            }
+        }
+    };
+}
+
+macro_rules! impl_numeric_zero_constructors {
+    ($name: ident) => {
+        impl_numeric_zero_constructor!($name, i8, 0);
+        impl_numeric_zero_constructor!($name, i16, 0);
+        impl_numeric_zero_constructor!($name, i32, 0);
+        impl_numeric_zero_constructor!($name, i64, 0);
+        impl_numeric_zero_constructor!($name, i128, 0);
+        impl_numeric_zero_constructor!($name, u8, 0);
+        impl_numeric_zero_constructor!($name, u16, 0);
+        impl_numeric_zero_constructor!($name, u32, 0);
+        impl_numeric_zero_constructor!($name, u64, 0);
+        impl_numeric_zero_constructor!($name, u128, 0);
+        impl_numeric_zero_constructor!($name, f32, 0.0);
+        impl_numeric_zero_constructor!($name, f64, 0.0);
+    }
+}
+
 /// The `ConstGenericRingBuffer` struct is a `RingBuffer` implementation which does not require `alloc` but
 /// uses const generics instead.
 ///
@@ -97,6 +136,8 @@ impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
             .expect("const array ptr shouldn't be null!")
     }
 }
+
+impl_numeric_zero_constructors!(ConstGenericRingBuffer);
 
 impl<T, const CAP: usize> RingBufferRead<T> for ConstGenericRingBuffer<T, CAP> {
     fn dequeue(&mut self) -> Option<T> {
@@ -269,5 +310,33 @@ mod tests {
             let expected = expected[i];
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn test_zeroed_constructor() {
+        let obj_zeroed = ConstGenericRingBuffer::<i8, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<i16, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<i32, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<i64, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<i128, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<u8, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<u16, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<u32, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<u64, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<u128, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<f32, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0.0).count());
+        let obj_zeroed = ConstGenericRingBuffer::<f64, 8>::new_zeroed();
+        assert_eq!(8, obj_zeroed.iter().filter(|x| **x == 0.0).count());
     }
 }


### PR DESCRIPTION
This PR adds "zeroed constructors" for ring buffers of type i8-i128, u8-u128, f32, f64.
It enables scenarios where you want every index in the ring buffer to be valid from the beginning; initialized to zero.

- What do you think of it overall?
- **The code should be restructured before merge, it is not optimal yet**. Would you like a `macro.rs` file?