### PR TITLE
default initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ringbuffer"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     "Victor Roest <victor@xirion.net>",
     "Jonathan Dönszelmann <jonabent@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,15 +904,15 @@ mod tests {
     }
 
     #[test]
-    fn run_test_default_init() {
-        fn test_default_init(mut rb: impl RingBufferExt<i32>) {
+    fn run_test_default_fill() {
+        fn test_default_fill(mut rb: impl RingBufferExt<i32>) {
             for i in 0..rb.capacity() {
                 for _ in 0..i {
                     rb.push(1);
                 }
 
                 assert_eq!(rb.len(), i);
-                rb.init_default();
+                rb.fill_default();
                 assert_eq!(rb.len(), 4);
 
                 // 4x
@@ -923,8 +923,32 @@ mod tests {
             }
         }
 
-        test_default_init(AllocRingBuffer::with_capacity(4));
-        test_default_init(ConstGenericRingBuffer::<i32, 4>::new());
+        test_default_fill(AllocRingBuffer::with_capacity(4));
+        test_default_fill(ConstGenericRingBuffer::<i32, 4>::new());
+    }
+
+    #[test]
+    fn run_test_fill() {
+        fn test_fill(mut rb: impl RingBufferExt<i32>) {
+            for i in 0..rb.capacity() {
+                for _ in 0..i {
+                    rb.push(1);
+                }
+
+                assert_eq!(rb.len(), i);
+                rb.fill(3);
+                assert_eq!(rb.len(), 4);
+
+                // 4x
+                assert_eq!(rb.dequeue(), Some(3));
+                assert_eq!(rb.dequeue(), Some(3));
+                assert_eq!(rb.dequeue(), Some(3));
+                assert_eq!(rb.dequeue(), Some(3));
+            }
+        }
+
+        test_fill(AllocRingBuffer::with_capacity(4));
+        test_fill(ConstGenericRingBuffer::<i32, 4>::new());
     }
 
     mod test_dropping {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -903,6 +903,30 @@ mod tests {
         test_clone(ConstGenericRingBuffer::<i32, 4>::new());
     }
 
+    #[test]
+    fn run_test_default_init() {
+        fn test_default_init(mut rb: impl RingBufferExt<i32>) {
+            for i in 0..rb.capacity() {
+                for _ in 0..i {
+                    rb.push(1);
+                }
+
+                assert_eq!(rb.len(), i);
+                rb.init_default();
+                assert_eq!(rb.len(), 4);
+
+                // 4x
+                assert_eq!(rb.dequeue(), Some(0));
+                assert_eq!(rb.dequeue(), Some(0));
+                assert_eq!(rb.dequeue(), Some(0));
+                assert_eq!(rb.dequeue(), Some(0));
+            }
+        }
+
+        test_default_init(AllocRingBuffer::with_capacity(4));
+        test_default_init(ConstGenericRingBuffer::<i32, 4>::new());
+    }
+
     mod test_dropping {
         use super::*;
         use std::boxed::Box;

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -94,13 +94,17 @@ pub trait RingBufferExt<T>:
     fn fill_with<F: FnMut() -> T>(&mut self, f: F);
 
     /// Sets every element in the ringbuffer to it's default value
-    fn fill_default(&mut self) where T: Default
+    fn fill_default(&mut self)
+    where
+        T: Default,
     {
         self.fill_with(Default::default)
     }
 
     /// Sets every element in the ringbuffer to `value`
-    fn fill(&mut self, value: T) where T: Clone
+    fn fill(&mut self, value: T)
+    where
+        T: Clone,
     {
         self.fill_with(|| value.clone())
     }

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -90,15 +90,19 @@ pub trait RingBufferExt<T>:
     + IndexMut<isize>
     + FromIterator<T>
 {
-    /// Sets every element in the ringbuffer to `T::default()`.
-    /// resets the read and writepointer
-    fn init_default(&mut self)
-    where
-        T: Default,
+    /// Sets every element in the ringbuffer to the value returned by f.
+    fn fill_with<F: FnMut() -> T>(&mut self, f: F);
+
+    /// Sets every element in the ringbuffer to it's default value
+    fn fill_default(&mut self) where T: Default
     {
-        for _ in 0..self.capacity() {
-            self.push(T::default());
-        }
+        self.fill_with(Default::default)
+    }
+
+    /// Sets every element in the ringbuffer to `value`
+    fn fill(&mut self, value: T) where T: Clone
+    {
+        self.fill_with(|| value.clone())
     }
 
     /// Empties the buffer entirely. Sets the length to 0 but keeps the capacity allocated.

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -90,6 +90,17 @@ pub trait RingBufferExt<T>:
     + IndexMut<isize>
     + FromIterator<T>
 {
+    /// Sets every element in the ringbuffer to `T::default()`.
+    /// resets the read and writepointer
+    fn init_default(&mut self)
+    where
+        T: Default,
+    {
+        for _ in 0..self.capacity() {
+            self.push(T::default());
+        }
+    }
+
     /// Empties the buffer entirely. Sets the length to 0 but keeps the capacity allocated.
     fn clear(&mut self);
 

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -84,8 +84,7 @@ impl<T> RingBufferExt<T> for AllocRingBuffer<T> {
     );
 
     #[inline]
-    fn fill_with<F: FnMut() -> T>(&mut self, mut f: F)
-    {
+    fn fill_with<F: FnMut() -> T>(&mut self, mut f: F) {
         self.readptr = 0;
         self.writeptr = self.capacity;
         self.buf.fill_with(|| MaybeUninit::new(f()));

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -84,15 +84,13 @@ impl<T> RingBufferExt<T> for AllocRingBuffer<T> {
     );
 
     #[inline]
-    fn init_default(&mut self)
-    where
-        T: Default,
+    fn fill_with<F: FnMut() -> T>(&mut self, mut f: F)
     {
         self.readptr = 0;
         self.writeptr = self.capacity;
-        self.buf.fill_with(|| MaybeUninit::new(Default::default()));
+        self.buf.fill_with(|| MaybeUninit::new(f()));
         while self.buf.len() < self.capacity {
-            self.buf.push(MaybeUninit::new(Default::default()));
+            self.buf.push(MaybeUninit::new(f()));
         }
     }
 }

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -82,6 +82,19 @@ impl<T> RingBufferExt<T> for AllocRingBuffer<T> {
         writeptr,
         crate::mask
     );
+
+    #[inline]
+    fn init_default(&mut self)
+    where
+        T: Default,
+    {
+        self.readptr = 0;
+        self.writeptr = self.capacity;
+        self.buf.fill_with(|| MaybeUninit::new(Default::default()));
+        while self.buf.len() < self.capacity {
+            self.buf.push(MaybeUninit::new(Default::default()));
+        }
+    }
 }
 
 impl<T> RingBufferRead<T> for AllocRingBuffer<T> {
@@ -186,7 +199,7 @@ impl<T> AllocRingBuffer<T> {
         Self::with_capacity_unchecked(cap)
     }
 
-    /// Creates a `AllocRingBuffer` with a capacity of [`RINGBUFFER_DEFAULT_CAPACITY`].
+    /// Creates an `AllocRingBuffer` with a capacity of [`RINGBUFFER_DEFAULT_CAPACITY`].
     #[inline]
     pub fn new() -> Self {
         Self::default()

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -160,13 +160,11 @@ impl<T, const CAP: usize> RingBufferExt<T> for ConstGenericRingBuffer<T, CAP> {
     );
 
     #[inline]
-    fn init_default(&mut self)
-    where
-        T: Default,
+    fn fill_with<F: FnMut() -> T>(&mut self, mut f: F)
     {
         self.readptr = 0;
         self.writeptr = CAP;
-        self.buf.fill_with(|| MaybeUninit::new(Default::default()));
+        self.buf.fill_with(|| MaybeUninit::new(f()));
     }
 }
 

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -160,8 +160,7 @@ impl<T, const CAP: usize> RingBufferExt<T> for ConstGenericRingBuffer<T, CAP> {
     );
 
     #[inline]
-    fn fill_with<F: FnMut() -> T>(&mut self, mut f: F)
-    {
+    fn fill_with<F: FnMut() -> T>(&mut self, mut f: F) {
         self.readptr = 0;
         self.writeptr = CAP;
         self.buf.fill_with(|| MaybeUninit::new(f()));

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -158,6 +158,16 @@ impl<T, const CAP: usize> RingBufferExt<T> for ConstGenericRingBuffer<T, CAP> {
         writeptr,
         crate::mask
     );
+
+    #[inline]
+    fn init_default(&mut self)
+    where
+        T: Default,
+    {
+        self.readptr = 0;
+        self.writeptr = CAP;
+        self.buf.fill_with(|| MaybeUninit::new(Default::default()));
+    }
 }
 
 impl<T, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP> {


### PR DESCRIPTION
adds an `init_default` method which initializes the full ringbuffer with default elements. It's a method so you can choose what kind of backing buffer there will be beforehand (avoiding the need for a number of methods like `init_default_with_capacity` and `init_default_new` etc). 

Example usage:
```rust
let mut rb = AllocRingBuffer::with_capacity(32);
rb.fill_default();
```


Note: you can't do: 
```rust
let mut rb = AllocRingBuffer::with_capacity(32).fill_default();
```

because that'd mean we'd need to put a Self:Sized bound on `init_default()`. That's fine in this case, but without the bound you can also later reuse `init_default()` to clear the ringbuffer and re-initialize it.
