### PR TITLE
alloc feature works with no_std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,3 +95,22 @@ jobs:
       with:
         command: test
         args: --all-features
+
+  build-no-std:
+    name: Build no-std
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install stable no-std toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: thumbv7em-none-eabihf
+        override: true
+
+    - name: Run cargo build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --target thumbv7em-none-eabihf --all-features

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn main() {
 
 | name | default | description |
 | --- | --- | --- |
-| alloc | ✓ | Disable this feature to remove the dependency on alloc. Useful for kernels. |
+| alloc | ✓ | Disable this feature to remove the dependency on alloc. The feature is compatible with `no_std`. |
 
 # License
 

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -3,7 +3,6 @@ use core::ops::{Index, IndexMut};
 use crate::ringbuffer_trait::{RingBuffer, RingBufferExt, RingBufferRead, RingBufferWrite};
 
 extern crate alloc;
-extern crate std;
 // We need vecs so depend on alloc
 use alloc::vec::Vec;
 use core::iter::FromIterator;


### PR DESCRIPTION
Hi. Unfortunately, this crate doesn't build in `no_std`-contexts when the `alloc`-feature is used. There is no technical reason for this limitation. Furthermore, even custom kernels can use things that need `alloc`, if you provide a custom global allcoator. (I did some kernel development with Rust; I can confirm). 

Github CI needs an update to check the no_std-build as well. I recommend the two following commands for the CI (I do it in my own projects):

- `$ rustup target add thumbv7em-none-eabihf` (install some no_std target)
- `$ cargo build --target thumbv7em-none-eabihf` \
  (cargo test will not work, because the crates `std` and `test` are not available for thumbv7em-none-eabihf)

I didn't include it in this PR, because I'm not that familiar yet with the github CI yaml syntax and the workflow file of this project looks different to the ones I'm used to.