### PR TITLE
Use all instead of fold

### DIFF
--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -63,7 +63,7 @@ impl<T: PartialEq> PartialEq for AllocRingBuffer<T> {
             && self
                 .iter()
                 .zip(other.iter())
-                .fold(true, |p, (a, b)| p && a == b)
+                .all(|(a, b)| a == b)
     }
 }
 


### PR DESCRIPTION
Change `fold` to `all` to improve readability. I would argue this MAY be faster because is exits early on non equal elements, but inspection of assembly or benchmark is needed to determine such.