### PR TITLE
remove power of two check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures"]
 license = "MIT"
 
 [dev-dependencies]
-criterion = "0.1.2"
+criterion = "0.4.0"
 compiletest_rs = "0.9.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ringbuffer"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     "Victor Roest <victor@xirion.net>",
     "Jonathan Dönszelmann <jonabent@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ const_panic = "0.2"
 
 [dev-dependencies]
 criterion = "0.1.2"
+compiletest_rs = "0.9.0"
 
 [features]
 default = ["alloc"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -98,8 +98,6 @@ fn benchmark_power_of_two<const L: usize>(b: &mut Bencher) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.with_plots();
-
     // TODO: Improve benchmarks
     // * What are representative operations
     // * Make sure it's accurate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! # License
 //!
-//! Licensed under GNU Lesser General Public License v3.0
+//! Licensed under the MIT License
 
 #[macro_use]
 pub(crate) mod ringbuffer_trait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,12 @@ const fn mask(cap: usize, index: usize) -> usize {
     index & (cap - 1)
 }
 
+/// Used internally. Computes the bitmask used to properly wrap the ringbuffers.
+#[inline]
+const fn mask_modulo(cap: usize, index: usize) -> usize {
+    index % cap
+}
+
 #[cfg(test)]
 #[allow(non_upper_case_globals)]
 mod tests {

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -6,8 +6,36 @@ extern crate alloc;
 // We need vecs so depend on alloc
 use alloc::vec::Vec;
 use core::iter::FromIterator;
+use core::marker::PhantomData;
 use core::mem;
 use core::mem::MaybeUninit;
+
+#[derive(Debug, Copy, Clone)]
+pub struct PowerOfTwo;
+#[derive(Debug, Copy, Clone)]
+pub struct NonPowerOfTwo;
+mod private {
+    use crate::with_alloc::{NonPowerOfTwo, PowerOfTwo};
+
+    pub trait Sealed {}
+    impl Sealed for PowerOfTwo {}
+    impl Sealed for NonPowerOfTwo {}
+}
+pub trait RingbufferMode: private::Sealed {
+    fn mask(cap: usize, index: usize) -> usize;
+}
+impl RingbufferMode for PowerOfTwo {
+    #[inline]
+    fn mask(cap: usize, index: usize) -> usize {
+        crate::mask(cap, index)
+    }
+}
+impl RingbufferMode for NonPowerOfTwo {
+    #[inline]
+    fn mask(cap: usize, index: usize) -> usize {
+        crate::mask_modulo(cap, index)
+    }
+}
 
 /// The `AllocRingBuffer` is a `RingBufferExt` which is based on a Vec. This means it allocates at runtime
 /// on the heap, and therefore needs the [`alloc`] crate. This struct and therefore the dependency on
@@ -36,27 +64,37 @@ use core::mem::MaybeUninit;
 /// assert_eq!(buffer.to_vec(), vec![42, 1]);
 /// ```
 #[derive(Debug)]
-pub struct AllocRingBuffer<T> {
+pub struct AllocRingBuffer<T, MODE: RingbufferMode = PowerOfTwo> {
     buf: Vec<MaybeUninit<T>>,
     capacity: usize,
     readptr: usize,
     writeptr: usize,
+    mode: PhantomData<MODE>,
 }
 
-impl<T> Drop for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> Drop for AllocRingBuffer<T, MODE> {
     fn drop(&mut self) {
         self.drain().for_each(drop);
     }
 }
 
-impl<T: Clone> Clone for AllocRingBuffer<T> {
+impl<T: Clone> Clone for AllocRingBuffer<T, PowerOfTwo> {
     fn clone(&self) -> Self {
         let mut new = Self::with_capacity(self.capacity);
         self.iter().cloned().for_each(|i| new.push(i));
         new
     }
 }
-impl<T: PartialEq> PartialEq for AllocRingBuffer<T> {
+
+impl<T: Clone> Clone for AllocRingBuffer<T, NonPowerOfTwo> {
+    fn clone(&self) -> Self {
+        let mut new = Self::with_capacity_non_power_of_two(self.capacity);
+        self.iter().cloned().for_each(|i| new.push(i));
+        new
+    }
+}
+
+impl<T: PartialEq, MODE: RingbufferMode> PartialEq for AllocRingBuffer<T, MODE> {
     fn eq(&self, other: &Self) -> bool {
         self.capacity == other.capacity
             && self.len() == other.len()
@@ -64,19 +102,19 @@ impl<T: PartialEq> PartialEq for AllocRingBuffer<T> {
     }
 }
 
-impl<T: Eq + PartialEq> Eq for AllocRingBuffer<T> {}
+impl<T: Eq + PartialEq, MODE: RingbufferMode> Eq for AllocRingBuffer<T, MODE> {}
 
 /// The capacity of a `RingBuffer` created by new or default (`1024`).
 // must be a power of 2
 pub const RINGBUFFER_DEFAULT_CAPACITY: usize = 1024;
 
-unsafe impl<T> RingBufferExt<T> for AllocRingBuffer<T> {
+unsafe impl<T, MODE: RingbufferMode> RingBufferExt<T> for AllocRingBuffer<T, MODE> {
     impl_ringbuffer_ext!(
         get_unchecked,
         get_unchecked_mut,
         readptr,
         writeptr,
-        crate::mask
+        MODE::mask
     );
 
     #[inline]
@@ -92,12 +130,12 @@ unsafe impl<T> RingBufferExt<T> for AllocRingBuffer<T> {
     }
 }
 
-impl<T> RingBufferRead<T> for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> RingBufferRead<T> for AllocRingBuffer<T, MODE> {
     fn dequeue(&mut self) -> Option<T> {
         if self.is_empty() {
             None
         } else {
-            let index = crate::mask(self.capacity, self.readptr);
+            let index = MODE::mask(self.capacity, self.readptr);
             let res = mem::replace(&mut self.buf[index], MaybeUninit::uninit());
             self.readptr += 1;
 
@@ -111,7 +149,7 @@ impl<T> RingBufferRead<T> for AllocRingBuffer<T> {
     impl_ringbuffer_read!();
 }
 
-impl<T> Extend<T> for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> Extend<T> for AllocRingBuffer<T, MODE> {
     fn extend<A: IntoIterator<Item = T>>(&mut self, iter: A) {
         let iter = iter.into_iter();
 
@@ -121,12 +159,12 @@ impl<T> Extend<T> for AllocRingBuffer<T> {
     }
 }
 
-impl<T> RingBufferWrite<T> for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> RingBufferWrite<T> for AllocRingBuffer<T, MODE> {
     #[inline]
     fn push(&mut self, value: T) {
         if self.is_full() {
             let previous_value = mem::replace(
-                &mut self.buf[crate::mask(self.capacity, self.readptr)],
+                &mut self.buf[MODE::mask(self.capacity, self.readptr)],
                 MaybeUninit::uninit(),
             );
             // make sure we drop whatever is being overwritten
@@ -140,7 +178,7 @@ impl<T> RingBufferWrite<T> for AllocRingBuffer<T> {
             self.readptr += 1;
         }
 
-        let index = crate::mask(self.capacity, self.writeptr);
+        let index = MODE::mask(self.capacity, self.writeptr);
 
         if index >= self.buf.len() {
             // initializing the maybeuninit when values are inserted/pushed
@@ -154,7 +192,7 @@ impl<T> RingBufferWrite<T> for AllocRingBuffer<T> {
     }
 }
 
-impl<T> RingBuffer<T> for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> RingBuffer<T> for AllocRingBuffer<T, MODE> {
     #[inline]
     unsafe fn ptr_capacity(rb: *const Self) -> usize {
         (*rb).capacity
@@ -163,24 +201,43 @@ impl<T> RingBuffer<T> for AllocRingBuffer<T> {
     impl_ringbuffer!(readptr, writeptr);
 }
 
-impl<T> AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> AllocRingBuffer<T, MODE> {
     /// Creates a `AllocRingBuffer` with a certain capacity. This capacity is fixed.
     /// for this ringbuffer to work, cap must be a power of two and greater than zero.
+    ///
+    /// # Safety
+    /// Only safe if the capacity is greater than zero, and a power of two.
+    /// Only if Mode == NonPowerOfTwo can the capacity be not a power of two, in which case this function is also safe.
     #[inline]
-    pub fn with_capacity_unchecked(cap: usize) -> Self {
+    unsafe fn with_capacity_unchecked(cap: usize) -> Self {
         Self {
             buf: Vec::with_capacity(cap),
             capacity: cap,
             readptr: 0,
             writeptr: 0,
+            mode: Default::default(),
         }
     }
+}
 
+impl<T> AllocRingBuffer<T, NonPowerOfTwo> {
+    /// Creates a `AllocRingBuffer` with a certain capacity. This capacity is fixed.
+    /// for this ringbuffer to work, cap must be a power of two and greater than zero.
+    #[inline]
+    pub fn with_capacity_non_power_of_two(cap: usize) -> Self {
+        assert_ne!(cap, 0, "Capacity must be greater than 0");
+
+        // Safety: Mode is NonPowerOfTwo and we checked above that the capacity isn't zero
+        unsafe { Self::with_capacity_unchecked(cap) }
+    }
+}
+
+impl<T> AllocRingBuffer<T, PowerOfTwo> {
     /// Creates a `AllocRingBuffer` with a certain capacity. The actual capacity is the input to the
     /// function raised to the power of two (effectively the input is the log2 of the actual capacity)
     #[inline]
     pub fn with_capacity_power_of_2(cap_power_of_two: usize) -> Self {
-        Self::with_capacity_unchecked(1 << cap_power_of_two)
+        unsafe { Self::with_capacity_unchecked(1 << cap_power_of_two) }
     }
 
     #[inline]
@@ -191,7 +248,8 @@ impl<T> AllocRingBuffer<T> {
         assert_ne!(cap, 0, "Capacity must be greater than 0");
         assert!(cap.is_power_of_two(), "Capacity must be a power of two");
 
-        Self::with_capacity_unchecked(cap)
+        // Safety
+        unsafe { Self::with_capacity_unchecked(cap) }
     }
 
     /// Creates an `AllocRingBuffer` with a capacity of [`RINGBUFFER_DEFAULT_CAPACITY`].
@@ -204,7 +262,10 @@ impl<T> AllocRingBuffer<T> {
 /// Get a reference from the buffer without checking it is initialized.
 /// Caller must be sure the index is in bounds, or this will panic.
 #[inline]
-unsafe fn get_unchecked<'a, T>(rb: *const AllocRingBuffer<T>, index: usize) -> &'a T {
+unsafe fn get_unchecked<'a, T, MODE: RingbufferMode>(
+    rb: *const AllocRingBuffer<T, MODE>,
+    index: usize,
+) -> &'a T {
     let p = &(*rb).buf[index];
     // Safety: caller makes sure the index is in bounds for the ringbuffer.
     // All in bounds values in the ringbuffer are initialized
@@ -214,7 +275,10 @@ unsafe fn get_unchecked<'a, T>(rb: *const AllocRingBuffer<T>, index: usize) -> &
 /// Get a mut reference from the buffer without checking it is initialized.
 /// Caller must be sure the index is in bounds, or this will panic.
 #[inline]
-unsafe fn get_unchecked_mut<T>(rb: *mut AllocRingBuffer<T>, index: usize) -> *mut T {
+unsafe fn get_unchecked_mut<T, MODE: RingbufferMode>(
+    rb: *mut AllocRingBuffer<T, MODE>,
+    index: usize,
+) -> *mut T {
     let p = (*rb).buf.as_mut_ptr().add(index);
 
     // Safety: caller makes sure the index is in bounds for the ringbuffer.
@@ -222,7 +286,7 @@ unsafe fn get_unchecked_mut<T>(rb: *mut AllocRingBuffer<T>, index: usize) -> *mu
     p.cast()
 }
 
-impl<RB> FromIterator<RB> for AllocRingBuffer<RB> {
+impl<RB, MODE: RingbufferMode> FromIterator<RB> for AllocRingBuffer<RB, MODE> {
     fn from_iter<T: IntoIterator<Item = RB>>(iter: T) -> Self {
         let mut res = Self::default();
         for i in iter {
@@ -233,7 +297,7 @@ impl<RB> FromIterator<RB> for AllocRingBuffer<RB> {
     }
 }
 
-impl<T> Default for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> Default for AllocRingBuffer<T, MODE> {
     /// Creates a buffer with a capacity of [`crate::RINGBUFFER_DEFAULT_CAPACITY`].
     #[inline]
     fn default() -> Self {
@@ -242,11 +306,12 @@ impl<T> Default for AllocRingBuffer<T> {
             capacity: RINGBUFFER_DEFAULT_CAPACITY,
             readptr: 0,
             writeptr: 0,
+            mode: Default::default(),
         }
     }
 }
 
-impl<T> Index<isize> for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> Index<isize> for AllocRingBuffer<T, MODE> {
     type Output = T;
 
     fn index(&self, index: isize) -> &Self::Output {
@@ -254,7 +319,7 @@ impl<T> Index<isize> for AllocRingBuffer<T> {
     }
 }
 
-impl<T> IndexMut<isize> for AllocRingBuffer<T> {
+impl<T, MODE: RingbufferMode> IndexMut<isize> for AllocRingBuffer<T, MODE> {
     fn index_mut(&mut self, index: isize) -> &mut Self::Output {
         self.get_mut(index).expect("index out of bounds")
     }
@@ -264,8 +329,30 @@ impl<T> IndexMut<isize> for AllocRingBuffer<T> {
 mod tests {
     use super::alloc::vec::Vec;
     use crate::{
-        AllocRingBuffer, RingBuffer, RingBufferExt, RingBufferWrite, RINGBUFFER_DEFAULT_CAPACITY,
+        AllocRingBuffer, RingBuffer, RingBufferExt, RingBufferRead, RingBufferWrite,
+        RINGBUFFER_DEFAULT_CAPACITY,
     };
+
+    #[test]
+    fn test_not_power_of_two() {
+        let mut rb = AllocRingBuffer::with_capacity_non_power_of_two(10);
+        const NUM_VALS: usize = 1000;
+
+        // recycle the ringbuffer a bunch of time to see if noneof the logic
+        // messes up
+        for _ in 0..100 {
+            for i in 0..NUM_VALS {
+                rb.enqueue(i);
+            }
+            assert!(rb.is_full());
+
+            for i in 0..10 {
+                assert_eq!(Some(i + NUM_VALS - rb.capacity()), rb.dequeue())
+            }
+
+            assert!(rb.is_empty())
+        }
+    }
 
     #[test]
     fn test_default() {

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -238,7 +238,7 @@ impl<T> AllocRingBuffer<T, NonPowerOfTwo> {
     /// as the ones constructed with `with_capacity`) can be up to 3x slower
     ///
     /// # Panics
-    /// if the capacity is zeroa
+    /// if the capacity is zero
     #[inline]
     pub fn with_capacity_non_power_of_two(cap: usize) -> Self {
         assert_ne!(cap, 0, "Capacity must be greater than 0");
@@ -253,6 +253,7 @@ impl<T> AllocRingBuffer<T, PowerOfTwo> {
     /// function raised to the power of two (effectively the input is the log2 of the actual capacity)
     #[inline]
     pub fn with_capacity_power_of_2(cap_power_of_two: usize) -> Self {
+        // Safety: 1 << n is always a power of two, and nonzero
         unsafe { Self::with_capacity_unchecked(1 << cap_power_of_two) }
     }
 
@@ -264,7 +265,7 @@ impl<T> AllocRingBuffer<T, PowerOfTwo> {
         assert_ne!(cap, 0, "Capacity must be greater than 0");
         assert!(cap.is_power_of_two(), "Capacity must be a power of two");
 
-        // Safety
+        // Safety: assertions check that cap is a power of two and nonzero
         unsafe { Self::with_capacity_unchecked(cap) }
     }
 

--- a/src/with_alloc.rs
+++ b/src/with_alloc.rs
@@ -222,7 +222,17 @@ impl<T, MODE: RingbufferMode> AllocRingBuffer<T, MODE> {
 
 impl<T> AllocRingBuffer<T, NonPowerOfTwo> {
     /// Creates a `AllocRingBuffer` with a certain capacity. This capacity is fixed.
-    /// for this ringbuffer to work, cap must be a power of two and greater than zero.
+    /// for this ringbuffer to work, and must not be zero.
+    ///
+    /// Note, that not using a power of two means some operations can't be optimized as well.
+    /// For example, bitwise ands might become modulos.
+    ///
+    /// For example, on push operations, benchmarks have shown that a ringbuffer with a power-of-two
+    /// capacity constructed with `with_capacity_non_power_of_two` (so which don't get the same optimization
+    /// as the ones constructed with `with_capacity`) can be up to 3x slower
+    ///
+    /// # Panics
+    /// if the capacity is zeroa
     #[inline]
     pub fn with_capacity_non_power_of_two(cap: usize) -> Self {
         assert_ne!(cap, 0, "Capacity must be greater than 0");

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -76,6 +76,9 @@ impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
         assert!(CAP != 0, "Capacity is not allowed to be zero");
 
     /// Creates a const generic ringbuffer, size is passed as a const generic.
+    ///
+    /// Note that the size does not have to be a power of two, but that not using a power
+    /// of two might be significantly (up to 3 times) slower.
     #[inline]
     pub const fn new() -> Self {
         #[allow(clippy::let_unit_value)]

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -72,10 +72,14 @@ impl<T: PartialEq, const CAP: usize> PartialEq for ConstGenericRingBuffer<T, CAP
 impl<T: PartialEq, const CAP: usize> Eq for ConstGenericRingBuffer<T, CAP> {}
 
 impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
+    const ERROR_CAPACITY_IS_NOT_ALLOWED_TO_BE_ZERO: () =
+        assert!(CAP != 0, "Capacity is not allowed to be zero");
+
     /// Creates a const generic ringbuffer, size is passed as a const generic.
     #[inline]
     pub const fn new() -> Self {
-        assert!(CAP != 0, "Capacity is not allowed to be zero");
+        #[allow(clippy::let_unit_value)]
+        let _ = Self::ERROR_CAPACITY_IS_NOT_ALLOWED_TO_BE_ZERO;
 
         // allow here since we are constructing an array of MaybeUninit<T>
         // which explicitly *is* defined behavior
@@ -231,12 +235,6 @@ impl<T, const CAP: usize> IndexMut<isize> for ConstGenericRingBuffer<T, CAP> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    #[should_panic]
-    fn test_no_empty() {
-        let _ = ConstGenericRingBuffer::<u32, 0>::new();
-    }
 
     #[test]
     fn test_not_power_of_two() {

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -76,7 +76,6 @@ impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     #[inline]
     pub const fn new() -> Self {
         assert!(CAP != 0, "Capacity is not allowed to be zero");
-        assert!(CAP.is_power_of_two(), "Capacity must be a power of two");
 
         Self {
             buf: unsafe { MaybeUninit::uninit().assume_init() },
@@ -115,7 +114,7 @@ impl<T, const CAP: usize> RingBufferRead<T> for ConstGenericRingBuffer<T, CAP> {
         if self.is_empty() {
             None
         } else {
-            let index = crate::mask(CAP, self.readptr);
+            let index = crate::mask_modulo(CAP, self.readptr);
             let res = mem::replace(&mut self.buf[index], MaybeUninit::uninit());
             self.readptr += 1;
 
@@ -144,7 +143,7 @@ impl<T, const CAP: usize> RingBufferWrite<T> for ConstGenericRingBuffer<T, CAP> 
     fn push(&mut self, value: T) {
         if self.is_full() {
             let previous_value = mem::replace(
-                &mut self.buf[crate::mask(CAP, self.readptr)],
+                &mut self.buf[crate::mask_modulo(CAP, self.readptr)],
                 MaybeUninit::uninit(),
             );
             // make sure we drop whatever is being overwritten
@@ -156,7 +155,7 @@ impl<T, const CAP: usize> RingBufferWrite<T> for ConstGenericRingBuffer<T, CAP> 
             }
             self.readptr += 1;
         }
-        let index = crate::mask(CAP, self.writeptr);
+        let index = crate::mask_modulo(CAP, self.writeptr);
         self.buf[index] = MaybeUninit::new(value);
         self.writeptr += 1;
     }
@@ -168,7 +167,7 @@ unsafe impl<T, const CAP: usize> RingBufferExt<T> for ConstGenericRingBuffer<T, 
         get_unchecked_mut,
         readptr,
         writeptr,
-        crate::mask
+        crate::mask_modulo
     );
 
     #[inline]
@@ -236,9 +235,24 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_with_capacity_no_power_of_two() {
-        let _ = ConstGenericRingBuffer::<i32, 10>::new();
+    fn test_not_power_of_two() {
+        let mut rb = ConstGenericRingBuffer::<usize, 10>::new();
+        const NUM_VALS: usize = 1000;
+
+        // recycle the ringbuffer a bunch of time to see if noneof the logic
+        // messes up
+        for _ in 0..100 {
+            for i in 0..NUM_VALS {
+                rb.enqueue(i);
+            }
+            assert!(rb.is_full());
+
+            for i in 0..10 {
+                assert_eq!(Some(i + NUM_VALS - rb.capacity()), rb.dequeue())
+            }
+
+            assert!(rb.is_empty())
+        }
     }
 
     #[test]

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -77,6 +77,10 @@ impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     pub const fn new() -> Self {
         assert!(CAP != 0, "Capacity is not allowed to be zero");
 
+        // allow here since we are constructing an array of MaybeUninit<T>
+        // which explicitly *is* defined behavior
+        // https://rust-lang.github.io/rust-clippy/master/index.html#uninit_assumed_init
+        #[allow(clippy::uninit_assumed_init)]
         Self {
             buf: unsafe { MaybeUninit::uninit().assume_init() },
             writeptr: 0,

--- a/tests/compile-fail/test_const_generic_array_zero_length.rs
+++ b/tests/compile-fail/test_const_generic_array_zero_length.rs
@@ -1,0 +1,9 @@
+extern crate ringbuffer;
+
+use ringbuffer::ConstGenericRingBuffer;
+
+fn main() {
+    let _ = ConstGenericRingBuffer::<i32, 0>::new();
+    //~^ note: the above error was encountered while instantiating `fn ringbuffer::ConstGenericRingBuffer::<i32, 0>::new`
+    // ringbuffer can't be zero length
+}

--- a/tests/compiletests.rs
+++ b/tests/compiletests.rs
@@ -1,0 +1,19 @@
+extern crate compiletest_rs as compiletest;
+
+use std::path::PathBuf;
+
+fn run_mode(mode: &'static str) {
+    let mut config = compiletest::Config::default();
+
+    config.mode = mode.parse().expect("Invalid mode");
+    config.src_base = PathBuf::from(format!("tests/{}", mode));
+    config.link_deps(); // Populate config.target_rustcflags with dependencies on the path
+    config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
+
+    compiletest::run_tests(&config);
+}
+
+#[test]
+fn compile_test() {
+    run_mode("compile-fail");
+}


### PR DESCRIPTION
Replaces #76 (for at least the power of two check), addressing the last commments on #61 by @Sjord. They are completely right that the power of two requirements is actually not really necessary for the const generic ringbuffer as its compiled to the same bitshift anyway

Closes #61 
