### PR TITLE
A faster non-power-of-two ring buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ pub use with_alloc::RINGBUFFER_DEFAULT_CAPACITY;
 mod with_const_generics;
 pub use with_const_generics::ConstGenericRingBuffer;
 
+mod without_modulo;
+pub use without_modulo::ModFreeRingBuffer;
+
 /// Used internally. Computes the bitmask used to properly wrap the ringbuffers.
 #[inline]
 const fn mask(cap: usize, index: usize) -> usize {
@@ -93,11 +96,12 @@ mod tests {
     extern crate std;
 
     use core::fmt::Debug;
+    use core::num::NonZeroUsize;
     use std::vec;
     use std::vec::Vec;
 
     use crate::{
-        AllocRingBuffer, ConstGenericRingBuffer, RingBuffer, RingBufferExt, RingBufferWrite,
+        AllocRingBuffer, ConstGenericRingBuffer, ModFreeRingBuffer, RingBuffer, RingBufferExt, RingBufferWrite,
     };
 
     #[test]
@@ -114,7 +118,10 @@ mod tests {
 
         test_neg_index(AllocRingBuffer::with_capacity(capacity));
         test_neg_index(ConstGenericRingBuffer::<usize, capacity>::new());
+        test_neg_index(ModFreeRingBuffer::new(NonZeroUsize::new(capacity).unwrap()));
     }
+
+    // TODO: The following two tests are exactly identical...
 
     #[test]
     fn run_test_default() {
@@ -125,6 +132,7 @@ mod tests {
 
         test_default(AllocRingBuffer::with_capacity(8));
         test_default(ConstGenericRingBuffer::<i32, 8>::new());
+        test_default(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -136,6 +144,7 @@ mod tests {
 
         test_new(AllocRingBuffer::with_capacity(8));
         test_new(ConstGenericRingBuffer::<i32, 8>::new());
+        test_new(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -162,6 +171,7 @@ mod tests {
 
         test_len(AllocRingBuffer::with_capacity(8));
         test_len(ConstGenericRingBuffer::<i32, 8>::new());
+        test_len(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -181,6 +191,7 @@ mod tests {
 
         test_len_wrap(AllocRingBuffer::with_capacity(2));
         test_len_wrap(ConstGenericRingBuffer::<i32, 2>::new());
+        test_len_wrap(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -197,6 +208,7 @@ mod tests {
 
         test_clear(AllocRingBuffer::with_capacity(8));
         test_clear(ConstGenericRingBuffer::<i32, 8>::new());
+        test_clear(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -215,6 +227,7 @@ mod tests {
 
         test_empty(AllocRingBuffer::with_capacity(8));
         test_empty(ConstGenericRingBuffer::<i32, 8>::new());
+        test_empty(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -241,6 +254,7 @@ mod tests {
 
         test_iter(AllocRingBuffer::with_capacity(8));
         test_iter(ConstGenericRingBuffer::<i32, 8>::new());
+        test_iter(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[cfg(feature = "alloc")]
@@ -263,6 +277,7 @@ mod tests {
 
         test_iter(&string, AllocRingBuffer::with_capacity(8));
         test_iter(&string, ConstGenericRingBuffer::<&str, 8>::new());
+        test_iter(&string, ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -285,6 +300,7 @@ mod tests {
 
         test_double_iter(AllocRingBuffer::with_capacity(8));
         test_double_iter(ConstGenericRingBuffer::<i32, 8>::new());
+        test_double_iter(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -302,6 +318,7 @@ mod tests {
 
         test_iter_wrap(AllocRingBuffer::with_capacity(2));
         test_iter_wrap(ConstGenericRingBuffer::<i32, 2>::new());
+        test_iter_wrap(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -320,6 +337,7 @@ mod tests {
 
         test_iter_mut(AllocRingBuffer::with_capacity(8));
         test_iter_mut(ConstGenericRingBuffer::<i32, 8>::new());
+        test_iter_mut(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -338,6 +356,7 @@ mod tests {
 
         run_test_iter_mut_wrap(AllocRingBuffer::with_capacity(2));
         run_test_iter_mut_wrap(ConstGenericRingBuffer::<i32, 2>::new());
+        run_test_iter_mut_wrap(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -358,6 +377,7 @@ mod tests {
 
         run_test_iter_mut_wrap(AllocRingBuffer::with_capacity(2));
         run_test_iter_mut_wrap(ConstGenericRingBuffer::<i32, 2>::new());
+        run_test_iter_mut_wrap(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -372,6 +392,7 @@ mod tests {
 
         test_to_vec(AllocRingBuffer::with_capacity(8));
         test_to_vec(ConstGenericRingBuffer::<i32, 8>::new());
+        test_to_vec(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -387,6 +408,7 @@ mod tests {
 
         test_to_vec_wrap(AllocRingBuffer::with_capacity(2));
         test_to_vec_wrap(ConstGenericRingBuffer::<i32, 2>::new());
+        test_to_vec_wrap(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -398,6 +420,7 @@ mod tests {
 
         test_index(AllocRingBuffer::with_capacity(8));
         test_index(ConstGenericRingBuffer::<i32, 8>::new());
+        test_index(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -414,6 +437,7 @@ mod tests {
 
         test_index_mut(AllocRingBuffer::with_capacity(8));
         test_index_mut(ConstGenericRingBuffer::<i32, 8>::new());
+        test_index_mut(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -427,6 +451,7 @@ mod tests {
 
         test_peek_some(AllocRingBuffer::with_capacity(2));
         test_peek_some(ConstGenericRingBuffer::<i32, 2>::new());
+        test_peek_some(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -437,6 +462,7 @@ mod tests {
 
         test_peek_none(AllocRingBuffer::with_capacity(8));
         test_peek_none(ConstGenericRingBuffer::<i32, 8>::new());
+        test_peek_none(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -461,6 +487,7 @@ mod tests {
 
         test_get_relative(AllocRingBuffer::with_capacity(8));
         test_get_relative(ConstGenericRingBuffer::<i32, 8>::new());
+        test_get_relative(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -484,6 +511,7 @@ mod tests {
 
         test_wrapping_get_relative(AllocRingBuffer::with_capacity(2));
         test_wrapping_get_relative(ConstGenericRingBuffer::<i32, 2>::new());
+        test_wrapping_get_relative(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -494,6 +522,7 @@ mod tests {
 
         test_get_relative_zero_length(AllocRingBuffer::with_capacity(8));
         test_get_relative_zero_length(ConstGenericRingBuffer::<i32, 8>::new());
+        test_get_relative_zero_length(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -517,6 +546,7 @@ mod tests {
 
         test_get_relative_mut(AllocRingBuffer::with_capacity(8));
         test_get_relative_mut(ConstGenericRingBuffer::<i32, 8>::new());
+        test_get_relative_mut(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -542,6 +572,7 @@ mod tests {
 
         test_wrapping_get_relative_mut(AllocRingBuffer::with_capacity(2));
         test_wrapping_get_relative_mut(ConstGenericRingBuffer::<i32, 2>::new());
+        test_wrapping_get_relative_mut(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -552,6 +583,7 @@ mod tests {
 
         test_get_relative_mut_zero_length(AllocRingBuffer::with_capacity(8));
         test_get_relative_mut_zero_length(ConstGenericRingBuffer::<i32, 8>::new());
+        test_get_relative_mut_zero_length(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -573,6 +605,7 @@ mod tests {
 
         test_get_absolute(AllocRingBuffer::with_capacity(8));
         test_get_absolute(ConstGenericRingBuffer::<i32, 8>::new());
+        test_get_absolute(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -585,6 +618,7 @@ mod tests {
 
         test_from_iterator::<AllocRingBuffer<i32>>();
         test_from_iterator::<ConstGenericRingBuffer<i32, 1024>>();
+        // NOTE: ModFreeRingBuffer does not really implement `FromIterator`.
     }
 
     #[test]
@@ -597,6 +631,7 @@ mod tests {
 
         test_from_iterator_wrap::<AllocRingBuffer<i32>>();
         test_from_iterator_wrap::<ConstGenericRingBuffer<i32, 1024>>();
+        // NOTE: ModFreeRingBuffer does not really implement `FromIterator`.
     }
 
     #[test]
@@ -621,6 +656,7 @@ mod tests {
 
         test_get_relative_negative(AllocRingBuffer::with_capacity(8));
         test_get_relative_negative(ConstGenericRingBuffer::<i32, 8>::new());
+        test_get_relative_negative(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -635,6 +671,7 @@ mod tests {
 
         test_contains(AllocRingBuffer::with_capacity(8));
         test_contains(ConstGenericRingBuffer::<i32, 8>::new());
+        test_contains(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -649,6 +686,7 @@ mod tests {
 
         test_is_full(AllocRingBuffer::with_capacity(2));
         test_is_full(ConstGenericRingBuffer::<i32, 2>::new());
+        test_is_full(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -662,6 +700,7 @@ mod tests {
 
         test_front_some(AllocRingBuffer::with_capacity(2));
         test_front_some(ConstGenericRingBuffer::<i32, 2>::new());
+        test_front_some(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -672,6 +711,7 @@ mod tests {
 
         test_front_none(AllocRingBuffer::with_capacity(8));
         test_front_none(ConstGenericRingBuffer::<i32, 8>::new());
+        test_front_none(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -685,6 +725,7 @@ mod tests {
 
         test_back_some(AllocRingBuffer::with_capacity(2));
         test_back_some(ConstGenericRingBuffer::<i32, 2>::new());
+        test_back_some(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -695,6 +736,7 @@ mod tests {
 
         test_back_none(AllocRingBuffer::with_capacity(8));
         test_back_none(ConstGenericRingBuffer::<i32, 8>::new());
+        test_back_none(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -708,6 +750,7 @@ mod tests {
 
         test_front_some_mut(AllocRingBuffer::with_capacity(2));
         test_front_some_mut(ConstGenericRingBuffer::<i32, 2>::new());
+        test_front_some_mut(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -718,6 +761,7 @@ mod tests {
 
         test_front_none_mut(AllocRingBuffer::with_capacity(8));
         test_front_none_mut(ConstGenericRingBuffer::<i32, 8>::new());
+        test_front_none_mut(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -730,8 +774,8 @@ mod tests {
         }
 
         test_back_some_mut(AllocRingBuffer::with_capacity(2));
-
         test_back_some_mut(ConstGenericRingBuffer::<i32, 2>::new());
+        test_back_some_mut(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -741,8 +785,8 @@ mod tests {
         }
 
         test_back_none_mut(AllocRingBuffer::with_capacity(8));
-
         test_back_none_mut(ConstGenericRingBuffer::<i32, 8>::new());
+        test_back_none_mut(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -763,6 +807,7 @@ mod tests {
 
         run_test_dequeue(AllocRingBuffer::with_capacity(8));
         run_test_dequeue(ConstGenericRingBuffer::<i32, 8>::new());
+        run_test_dequeue(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -780,8 +825,8 @@ mod tests {
         }
 
         test_skip(AllocRingBuffer::with_capacity(8));
-
         test_skip(ConstGenericRingBuffer::<i32, 8>::new());
+        test_skip(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -799,6 +844,7 @@ mod tests {
 
         test_skip2(AllocRingBuffer::with_capacity(2));
         test_skip2(ConstGenericRingBuffer::<i32, 2>::new());
+        test_skip2(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -821,6 +867,7 @@ mod tests {
 
         test_push_dequeue_push(AllocRingBuffer::with_capacity(8));
         test_push_dequeue_push(ConstGenericRingBuffer::<i32, 8>::new());
+        test_push_dequeue_push(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -843,6 +890,7 @@ mod tests {
 
         test_enqueue_dequeue_push(AllocRingBuffer::with_capacity(8));
         test_enqueue_dequeue_push(ConstGenericRingBuffer::<i32, 8>::new());
+        test_enqueue_dequeue_push(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -867,6 +915,7 @@ mod tests {
 
         test_push_dequeue_push_full(AllocRingBuffer::with_capacity(2));
         test_push_dequeue_push_full(ConstGenericRingBuffer::<i32, 2>::new());
+        test_push_dequeue_push_full(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -899,6 +948,7 @@ mod tests {
 
         test_push_dequeue_push_full_get(AllocRingBuffer::with_capacity(2));
         test_push_dequeue_push_full_get(ConstGenericRingBuffer::<i32, 2>::new());
+        test_push_dequeue_push_full_get(ModFreeRingBuffer::new(NonZeroUsize::new(2).unwrap()));
     }
 
     #[test]
@@ -929,6 +979,7 @@ mod tests {
 
         test_push_dequeue_push_full_get_rep(AllocRingBuffer::with_capacity(8));
         test_push_dequeue_push_full_get_rep(ConstGenericRingBuffer::<i32, 8>::new());
+        test_push_dequeue_push_full_get_rep(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -952,6 +1003,7 @@ mod tests {
 
         test_clone(AllocRingBuffer::with_capacity(4));
         test_clone(ConstGenericRingBuffer::<i32, 4>::new());
+        test_clone(ModFreeRingBuffer::new(NonZeroUsize::new(4).unwrap()));
     }
 
     #[test]
@@ -976,10 +1028,13 @@ mod tests {
 
         test_default_fill(AllocRingBuffer::with_capacity(4));
         test_default_fill(ConstGenericRingBuffer::<i32, 4>::new());
+        test_default_fill(ModFreeRingBuffer::new(NonZeroUsize::new(4).unwrap()));
     }
 
     #[test]
     fn run_test_eq() {
+        // TODO: Also test AllocRingBuffer and ModFreeRingBuffer.
+
         let mut alloc_a = ConstGenericRingBuffer::<i32, 4>::new();
         let mut alloc_b = ConstGenericRingBuffer::<i32, 4>::new();
 
@@ -1010,6 +1065,7 @@ mod tests {
 
         next_back_test(ConstGenericRingBuffer::<i32, 8>::new());
         next_back_test(AllocRingBuffer::with_capacity(8));
+        next_back_test(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
 
     #[test]
@@ -1029,6 +1085,7 @@ mod tests {
 
         next_back_test_mut(ConstGenericRingBuffer::<i32, 8>::new());
         next_back_test_mut(AllocRingBuffer::with_capacity(8));
+        next_back_test_mut(ModFreeRingBuffer::new(NonZeroUsize::new(8).unwrap()));
     }
     #[test]
     fn run_test_fill() {
@@ -1052,6 +1109,7 @@ mod tests {
 
         test_fill(AllocRingBuffer::with_capacity(4));
         test_fill(ConstGenericRingBuffer::<i32, 4>::new());
+        test_fill(ModFreeRingBuffer::new(NonZeroUsize::new(4).unwrap()));
     }
 
     mod test_dropping {
@@ -1110,6 +1168,11 @@ mod tests {
         #[test]
         fn run_test_drops_contents_const_generic() {
             test_dropped!({ ConstGenericRingBuffer::<_, 1>::new() });
+        }
+
+        #[test]
+        fn run_test_drops_contents_mod_free() {
+            test_dropped!({ ModFreeRingBuffer::new(NonZeroUsize::new(1).unwrap()) });
         }
     }
 }

--- a/src/without_modulo.rs
+++ b/src/without_modulo.rs
@@ -1,0 +1,329 @@
+use core::fmt::{self, Debug};
+use core::mem::{self, MaybeUninit};
+use core::num::NonZeroUsize;
+use core::ops::{Index, IndexMut};
+
+extern crate alloc;
+use alloc::{boxed::Box, vec::Vec};
+
+use crate::ringbuffer_trait::*;
+
+/// A [`RingBuffer`] efficiently supporting non-power-of-two sizes.
+///
+/// Most ring-buffers use power-of-two capacities because indices can be wrapped
+/// to within the capacity very efficiently.  For non-power-of-two capacities, a
+/// modulo operation is incredibly expensive, so instead conditional subtraction
+/// is performed.  Because these subtractions only need to occur when the buffer
+/// wraps around, its relative cost decreases as the buffer capacity increases.
+pub struct ModFreeRingBuffer<T> {
+    /// The data buffer.
+    ///
+    /// The length of this slice is the capacity of the ring buffer.  It stores
+    /// the individual elements of the buffer, and uninitialized data for slots
+    /// that do not contain elements.
+    ///
+    /// The number of initialized elements in the data buffer is computed as
+    /// `dsti - srci`.  As such, if `dsti - srci == capacity`, then the buffer
+    /// is full.
+    data: Box<[MaybeUninit<T>]>,
+
+    /// The source index.
+    ///
+    /// This is the index of the first initialized element in the data buffer,
+    /// if the buffer is not empty.  This field is maintained within the range
+    /// `0 .. capacity`; as such, it can be used to directly index into the data
+    /// buffer.
+    srci: usize,
+
+    /// The destination index.
+    ///
+    /// This is the index in the data buffer where new elements will be added.
+    /// Note that this index may already contain an initialized element.  This
+    /// field is maintained within the range `srci ..= srci+capacity` (in more
+    /// absolute terms, `0 .. 2*capacity`); it is at most one subtraction away
+    /// from being a valid index into the data buffer.
+    ///
+    /// If the buffer is full, then this field is `srci + capacity`.  If this
+    /// field is strictly greater than `capacity`, then some elements lie at the
+    /// beginning of the data buffer, at positions less than the source index.
+    dsti: usize,
+}
+
+impl<T> ModFreeRingBuffer<T> {
+    /// Construct a new [`ModFreeRingBuffer`] with the given capacity.
+    #[inline]
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        // SAFETY: [`NonZeroUsize`] guarantees that the value is non-zero.
+        unsafe { Self::new_unchecked(capacity.get()) }
+    }
+
+    /// Construct a new [`ModFreeRingBuffer`] with the given capacity, without
+    /// checking that it is non-zero.
+    #[inline]
+    pub unsafe fn new_unchecked(capacity: usize) -> Self {
+        // NOTE: Use Box::new_uninit() when it stabilizes.
+        let mut data = Vec::with_capacity(capacity);
+        // SAFETY: `MaybeUninit` is is never uninitialized.
+        unsafe { data.set_len(capacity); }
+
+        Self { data: data.into_boxed_slice(), srci: 0, dsti: 0 }
+    }
+}
+
+impl<T> RingBuffer<T> for ModFreeRingBuffer<T> {
+    #[inline]
+    unsafe fn ptr_len(this: *const Self) -> usize {
+        (*this).dsti - (*this).srci
+    }
+
+    #[inline]
+    unsafe fn ptr_capacity(this: *const Self) -> usize {
+        (*this).data.len()
+    }
+}
+
+impl<T> RingBufferRead<T> for ModFreeRingBuffer<T> {
+    #[inline]
+    fn dequeue(&mut self) -> Option<T> {
+        if self.srci < self.dsti {
+            // SAFETY: `srci` is in range and `len` is non-zero, and `srci` will
+            // be incremented so that the slot is marked dead for future reads.
+            let slot = unsafe { self.data.get_unchecked_mut(self.srci) };
+            let item = unsafe { slot.assume_init_read() };
+
+            if self.srci + 1 == self.data.len() {
+                // NOTE: We need to wrap `dsti` because:
+                // - srci < dsti
+                // - srci == capacity - 1
+                // - capacity - 1 < dsti
+                // - capacity <= dsti
+                // So the new length (`dsti - srci`) would change incorrectly.
+                self.srci = 0;
+                self.dsti -= self.data.len();
+            } else { self.srci += 1; }
+
+            Some(item)
+        } else { None }
+    }
+
+    fn skip(&mut self) {
+        if self.srci < self.dsti {
+            // SAFETY: `srci` is in range and `len` is non-zero, and `srci` will
+            // be incremented so that the slot is marked dead for future reads.
+            let slot = unsafe { self.data.get_unchecked_mut(self.srci) };
+            unsafe { slot.assume_init_drop() };
+
+            if self.srci + 1 == self.data.len() {
+                self.srci = 0;
+            } else { self.srci += 1; }
+        }
+    }
+}
+
+impl<T> RingBufferWrite<T> for ModFreeRingBuffer<T> {
+    #[inline]
+    fn push(&mut self, value: T) {
+        let dsti = if self.dsti >= self.data.len() {
+            self.dsti - self.data.len()
+        } else { self.dsti };
+
+        // SAFETY: `dsti` has been conditionally subtracted into range.
+        let slot = unsafe { self.data.get_unchecked_mut(dsti) };
+        let mut prev = mem::replace(slot, MaybeUninit::new(value));
+
+        if self.dsti == self.srci + self.data.len() {
+            // SAFETY: The buffer is full, so `prev` must be initialized.
+            unsafe { prev.assume_init_drop() };
+
+            self.dsti += 1;
+            if self.dsti == 2 * self.data.len() {
+                self.srci = 0;
+                self.dsti = self.data.len();
+            } else {
+                self.srci += 1;
+            }
+        } else {
+            // NOTE: The buffer is not full, so:
+            // - dsti < srci + capacity
+            // - dsti + 1 < 1 + srci + capacity
+            // - dsti + 1 < 1 + capacity-1 + capacity
+            // - dsti + 1 < 2*capacity
+            self.dsti += 1;
+        }
+    }
+}
+
+unsafe impl<T> RingBufferExt<T> for ModFreeRingBuffer<T> {
+    fn fill_with<F: FnMut() -> T>(&mut self, mut f: F) {
+        self.clear();
+
+        for slot in self.data.iter_mut() {
+            *slot = MaybeUninit::new((f)());
+        }
+
+        self.srci = 0;
+        self.dsti = self.data.len();
+    }
+
+    fn clear(&mut self) {
+        while let Some(item) = self.dequeue() {
+            let _ = item;
+        }
+    }
+
+    fn get(&self, index: isize) -> Option<&T> {
+        let len_s = self.len() as isize;
+        let index = if len_s != 0 && (index <= -len_s || len_s < index) {
+            // We are forced to perform an expensive modulo, so we try to hide
+            // it behind a probably-unlikely branch.
+            index.rem_euclid(len_s) as usize
+        } else if len_s != 0 && (index < 0) {
+            (index + len_s) as usize
+        } else if len_s != 0 {
+            index as usize
+        } else { return None };
+
+        // NOTE: We know that `index` is now within `self.len()`, so it must be
+        // within `self.capacity()`.
+
+        let index = if self.srci + index >= self.data.len() {
+            self.srci + index - self.data.len()
+        } else { self.srci + index };
+
+        // SAFETY: We have confirmed that `index` is in `srci .. dsti`, so we
+        // are definitely referring to an element that is initialized.
+        Some(unsafe { self.data[index].assume_init_ref() })
+    }
+
+    unsafe fn ptr_get_mut(this: *mut Self, index: isize) -> Option<*mut T> {
+        let len_s = (*this).len() as isize;
+        let index = if len_s != 0 && (index <= -len_s || len_s < index) {
+            // We are forced to perform an expensive modulo, so we try to hide
+            // it behind a probably-unlikely branch.
+            index.rem_euclid(len_s) as usize
+        } else if len_s != 0 && (index < 0) {
+            (index + len_s) as usize
+        } else if len_s != 0 {
+            index as usize
+        } else { return None };
+
+        // NOTE: We know that `index` is now within `self.len()`, so it must be
+        // within `self.capacity()`.
+
+        let index = if (*this).srci + index >= (*this).data.len() {
+            (*this).srci + index - (*this).data.len()
+        } else { (*this).srci + index };
+
+        // SAFETY: We have confirmed that `index` is in `srci .. dsti`, so we
+        // are definitely referring to an element that is initialized.
+        Some(unsafe { (*this).data[index].assume_init_mut() })
+    }
+
+    fn get_absolute(&self, index: usize) -> Option<&T> {
+        let capacity = self.data.len();
+        if self.dsti > capacity {
+            // The data buffer contains a single uninitialized part.
+            if self.dsti - capacity <= index && index < self.srci {
+                return None;
+            }
+        } else {
+            // The data buffer contains two uninitialized parts.
+            if index < self.srci || self.dsti <= index {
+                return None;
+            }
+        }
+
+        // SAFETY: We have confirmed that `index` is in `srci .. dsti`, so we
+        // are definitely referring to an element that is initialized.
+        Some(unsafe { self.data[index].assume_init_ref() })
+    }
+
+    fn get_absolute_mut(&mut self, index: usize) -> Option<&mut T> {
+        let capacity = self.data.len();
+        if self.dsti > capacity {
+            // The data buffer contains a single uninitialized part.
+            if self.dsti - capacity <= index && index < self.srci {
+                return None;
+            }
+        } else {
+            // The data buffer contains two uninitialized parts.
+            if index < self.srci || self.dsti <= index {
+                return None;
+            }
+        }
+
+        // SAFETY: We have confirmed that `index` is in `srci .. dsti`, so we
+        // are definitely referring to an element that is initialized.
+        Some(unsafe { self.data[index].assume_init_mut() })
+    }
+}
+
+impl<T> Index<isize> for ModFreeRingBuffer<T> {
+    type Output = T;
+
+    fn index(&self, index: isize) -> &Self::Output {
+        self.get(index).expect("index out of bounds")
+    }
+}
+
+impl<T> IndexMut<isize> for ModFreeRingBuffer<T> {
+    fn index_mut(&mut self, index: isize) -> &mut Self::Output {
+        self.get_mut(index).expect("index out of bounds")
+    }
+}
+
+impl<T> Extend<T> for ModFreeRingBuffer<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for item in iter {
+            self.push(item);
+        }
+    }
+}
+
+impl<T> FromIterator<T> for ModFreeRingBuffer<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let _ = iter;
+        unimplemented!()
+    }
+}
+
+impl<T> Drop for ModFreeRingBuffer<T> {
+    fn drop(&mut self) {
+        // Items need to be dropped manually because of [`MaybeUninit`].
+        self.clear();
+    }
+}
+
+impl<T: Clone> Clone for ModFreeRingBuffer<T> {
+    fn clone(&self) -> Self {
+        // SAFETY: We know that our capacity is non-zero.
+        let mut clone = unsafe { Self::new_unchecked(self.data.len()) };
+        clone.extend(self.iter().cloned());
+        clone
+    }
+}
+
+impl<T: PartialEq> PartialEq for ModFreeRingBuffer<T> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.capacity() != other.capacity() { return false; }
+        self.iter().eq(other.iter())
+    }
+}
+
+impl<T: Eq> Eq for ModFreeRingBuffer<T> {}
+
+impl<T: Debug> Debug for ModFreeRingBuffer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct Wrapper<'a, T> { this: &'a ModFreeRingBuffer<T> }
+        impl<'a, T: Debug> Debug for Wrapper<'a, T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_list().entries(self.this.iter()).finish()
+            }
+        }
+
+        f.debug_struct("ModFreeRingBuffer")
+            .field("srci", &self.srci).field("dsti", &self.dsti)
+            .field("data", &Wrapper { this: self })
+            .finish()
+    }
+}


### PR DESCRIPTION
I've implemented my own `RingBuffer`, `ModFreeRingBuffer`, that uses conditional subtraction instead of expensive modulo operations.  It maintains a base index that is kept within a fixed range of the buffer, and is conditionally subtracted as necessary.  When used in a loop, the compiler is able to optimize the involved branches quite effectively.

`ModFreeRingBuffer` uses `alloc`, just like `AllocRingBuffer`; however, instead of using a `Vec`, I use a `Box` (the `Vec` stores an additional length argument that is unnecessary if we pre-allocate the capacity).  I've modified `AllocRingBuffer` to have the same optimization.

I've also integrated `ModFreeRingBuffer` with the benchmarking system; it beats `AllocRingBuffer<T, NonPowerOfTwo>`, and is very competitive (within 25% of the time taken) for `AllocRingBuffer<T, PowerOfTwo>`.  It can definitely be tuned further (for example, pointers can be used instead of indices, or indices can use units of bytes instead of elements).