### PR TITLE
`README`: make the ringbuffer names link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Implementations for three kinds of ringbuffers, with a mostly similar API are pr
 | [`GrowableAllocRingBuffer`][2] | Ringbuffer allocated on the heap at runtime. This ringbuffer can grow in size, and is implemented as an `alloc::VecDeque` internally. This requires alloc and the alloc feature. |
 | [`ConstGenericRingBuffer`][3]  | Ringbuffer which uses const generics to allocate on the stack.                                                                                                                   |
 
+All of these ringbuffers also implement the [RingBuffer][4] trait for their shared API surface.
+
 [1]: https://docs.rs/ringbuffer/latest/ringbuffer/struct.AllocRingBuffer.html
 [2]: https://docs.rs/ringbuffer/latest/ringbuffer/struct.GrowableAllocRingBuffer.html
 [3]: https://docs.rs/ringbuffer/latest/ringbuffer/struct.ConstGenericRingBuffer.html
-
-All of these ringbuffers also implement the RingBuffer trait for their shared API surface.
-
+[4]: https://docs.rs/ringbuffer/latest/ringbuffer/trait.RingBuffer.html
 
 MSRV: Rust 1.59
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@ The ringbuffer crate provides safe fixed size circular buffers (ringbuffers) in 
 
 Implementations for three kinds of ringbuffers, with a mostly similar API are provided:
 
-| type                      | description                                                                                                                                                                      |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `AllocRingBuffer`         | Ringbuffer allocated on the heap at runtime. This ringbuffer is still fixed size. This requires alloc and the alloc feature.                                                     |
-| `GrowableAllocRingBuffer` | Ringbuffer allocated on the heap at runtime. This ringbuffer can grow in size, and is implemented as an `alloc::VecDeque` internally. This requires alloc and the alloc feature. |
-| `ConstGenericRingBuffer`  | Ringbuffer which uses const generics to allocate on the stack.                                                                                                                   |
+| type                           | description                                                                                                                                                                      |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`AllocRingBuffer`][1]         | Ringbuffer allocated on the heap at runtime. This ringbuffer is still fixed size. This requires alloc and the alloc feature.                                                     |
+| [`GrowableAllocRingBuffer`][2] | Ringbuffer allocated on the heap at runtime. This ringbuffer can grow in size, and is implemented as an `alloc::VecDeque` internally. This requires alloc and the alloc feature. |
+| [`ConstGenericRingBuffer`][3]  | Ringbuffer which uses const generics to allocate on the stack.                                                                                                                   |
+
+[1]: https://docs.rs/ringbuffer/latest/ringbuffer/struct.AllocRingBuffer.html
+[2]: https://docs.rs/ringbuffer/latest/ringbuffer/struct.GrowableAllocRingBuffer.html
+[3]: https://docs.rs/ringbuffer/latest/ringbuffer/struct.ConstGenericRingBuffer.html
 
 All of these ringbuffers also implement the RingBuffer trait for their shared API surface.
 


### PR DESCRIPTION
These links seemed to have disappeared between 0.14 and the current `main` branch. Because the `README.md` is synced with the module documentation, the links will also show up there. But they won't link to the version you're currently looking at, but always to the latest version on [docs.rs]. Still this is a small improvement that will probably make sense for most users.

The alternative would be to write `[AllocRingBuffer]`, which makes sense for rustdoc, but won't create a valid link elsewhere (such as on GitHub).