### PR TITLE
`docs`: fix link to `VecDeque`

### DIFF
--- a/src/with_alloc/vecdeque.rs
+++ b/src/with_alloc/vecdeque.rs
@@ -5,7 +5,7 @@ use alloc::collections::VecDeque;
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 
 /// A growable ringbuffer. Once capacity is reached, the size is doubled.
-/// Wrapper of the built-in [`VecDeque`](std::collections::VecDeque) struct
+/// Wrapper of the built-in [`VecDeque`] struct.
 ///
 /// The reason this is a wrapper, is that we want `RingBuffers` to implement `Index<isize>`,
 /// which we cannot do for remote types like `VecDeque`


### PR DESCRIPTION
The link to `std::collections::VecDeque` was invalid because `std` was not in scope, but `VecDeque` was in scope via `alloc` so it didn't need an explicit link. This made rustdoc fail with the following error:
```
error: unresolved link to `std::collections::VecDeque`
 --> src/with_alloc/vecdeque.rs:8:42
  |
8 | /// Wrapper of the built-in [`VecDeque`](std::collections::VecDeque) struct
  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `std` in scope
  |
note: the lint level is defined here
 --> src/lib.rs:3:9
  |
3 | #![deny(warnings)]
  |         ^^^^^^^^
  = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(warnings)]`

error: could not document `ringbuffer`
```