### PR TITLE
make `skip` a provided method of `RingBufferRead`

### DIFF
--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -71,7 +71,10 @@ pub trait RingBufferRead<T>: RingBuffer<T> + IntoIterator<Item = T> {
 
     /// dequeues the top item off the queue, but does not return it. Instead it is dropped.
     /// If the ringbuffer is empty, this function is a nop.
-    fn skip(&mut self);
+    #[inline]
+    fn skip(&mut self) {
+        let _ = self.dequeue();
+    }
 
     /// Returns an iterator over the elements in the ringbuffer,
     /// dequeueing elements as they are iterated over.
@@ -419,17 +422,6 @@ mod iter {
 pub use iter::{
     RingBufferDrainingIterator, RingBufferIntoIterator, RingBufferIterator, RingBufferMutIterator,
 };
-
-/// Implement various functions on implementors of [`RingBufferRead`].
-/// This is to avoid duplicate code.
-macro_rules! impl_ringbuffer_read {
-    () => {
-        #[inline]
-        fn skip(&mut self) {
-            let _ = self.dequeue().map(drop);
-        }
-    };
-}
 
 /// Implement various functions on implementors of [`RingBuffer`].
 /// This is to avoid duplicate code.

--- a/src/with_alloc/alloc_ringbuffer.rs
+++ b/src/with_alloc/alloc_ringbuffer.rs
@@ -270,8 +270,6 @@ impl<T, SIZE: RingbufferSize> RingBufferRead<T> for AllocRingBuffer<T, SIZE> {
             unsafe { Some(ptr::read(res)) }
         }
     }
-
-    impl_ringbuffer_read!();
 }
 
 impl<T, SIZE: RingbufferSize> Extend<T> for AllocRingBuffer<T, SIZE> {

--- a/src/with_alloc/vecdeque.rs
+++ b/src/with_alloc/vecdeque.rs
@@ -165,8 +165,6 @@ impl<T> RingBufferRead<T> for GrowableAllocRingBuffer<T> {
     fn dequeue(&mut self) -> Option<T> {
         self.pop_front()
     }
-
-    impl_ringbuffer_read!();
 }
 
 impl<T> RingBufferWrite<T> for GrowableAllocRingBuffer<T> {

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -238,8 +238,6 @@ impl<T, const CAP: usize> RingBufferRead<T> for ConstGenericRingBuffer<T, CAP> {
             unsafe { Some(res.assume_init()) }
         }
     }
-
-    impl_ringbuffer_read!();
 }
 
 impl<T, const CAP: usize> Extend<T> for ConstGenericRingBuffer<T, CAP> {


### PR DESCRIPTION
`skip` was implemented with a macro that was repeated for all ringbuffers. I've copied the `#[inline]` attribute, but I don't really know whether `#[inline]` works on a provided method. I've also removed the `.map(drop)`, because I think it's unnecessary (correct me if I'm wrong).