### PR TITLE
Add a size parameter for `ConstGenericRingBuffer::new`

### DIFF
--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -174,7 +174,10 @@ impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     /// of two might be significantly (up to 3 times) slower.
     #[inline]
     #[must_use]
-    pub const fn new() -> Self {
+    pub const fn new<const N: usize>() -> Self
+    where
+        ConstGenericRingBuffer<T, CAP>: From<ConstGenericRingBuffer<T, N>>,
+    {
         #[allow(clippy::let_unit_value)]
         let _ = Self::ERROR_CAPACITY_IS_NOT_ALLOWED_TO_BE_ZERO;
 

--- a/tests/compile-fail/test_const_generic_array_zero_length_new.rs
+++ b/tests/compile-fail/test_const_generic_array_zero_length_new.rs
@@ -1,9 +1,10 @@
 extern crate ringbuffer;
 
-use ringbuffer::ConstGenericRingBuffer;
+use ringbuffer::{ConstGenericRingBuffer, RingBufferWrite};
 
 fn main() {
-    let _ = ConstGenericRingBuffer::<i32, 0>::new();
+    let mut buf = ConstGenericRingBuffer::new::<0>();
     //~^ note: the above error was encountered while instantiating `fn ringbuffer::ConstGenericRingBuffer::<i32, 0>::new::<0>`
     // ringbuffer can't be zero length
+    buf.push(5);
 }

--- a/tests/conversions.rs
+++ b/tests/conversions.rs
@@ -118,3 +118,18 @@ fn test_extra_conversions_const() {
     let a = ConstGenericRingBuffer::<_, 2>::from(a);
     assert_eq!(a.to_vec(), vec![1, 2]);
 }
+
+#[test]
+fn test_const_generic_new_parameter() {
+    // Can we specify size only on the method?
+    let mut a = ConstGenericRingBuffer::new::<2>();
+    a.push(5);
+
+    // Can we specify size in both positions?
+    let mut a = ConstGenericRingBuffer::<i32, 50>::new::<50>();
+    a.push(5);
+
+    // Can we specify size only on the struct?
+    let mut a = ConstGenericRingBuffer::<i32, 50>::new();
+    a.push(5);
+}


### PR DESCRIPTION
This is a minor ergonomic improvement which allows us to write:
```rust
ConstGenericRingBuffer::new::<5>()
```
instead of
```rust
ConstGenericRingBuffer::<_, 5>::new()
```
when the type can be inferred, saving a grand total of 2 characters (3 if you count the space)!

This trick (ab)uses `From` as a stand-in for an identity trait. This is probably fine, because there is only one possible implementation of the `from` method, which is the identity function, since `From` is guaranteed to be reflexive via a blanket impl.