### PR TITLE
README: add table with ringbuffer properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ fn main() {
 
 ```
 
+# Comparison of ringbuffer types
+
+| type                                          | heap allocated | growable | size must be power of 2 | `no_std` |
+| ----------------------------------------------|----------------|----------|-------------------------|----------|
+| `AllocRingBuffer<T, PowerOfTwo>`              | yes            | no       | yes                     | no       |
+| `AllocRingBuffer<T, NonPowerOfTwo>`           | yes            | no       | no                      | no       |
+| `GrowableAllocRingBuffer<T>`                  | yes            | yes      | no                      | no       |
+| `ConstGenericRingBuffer<T, const CAP: usize>` | no             | no       | no[^1]                  | yes      |
+
+[^1]: Using a size that is not a power of 2 will be ~3x slower.
+
 # Features
 
 | name  | default | description                                                                                                  |


### PR DESCRIPTION
I thought an overview of features of the ringbuffers was missing, even though the descriptions technically cover most of it. The README currently also lacks some info about where powers of two are important, so I added a bit of that here too.

I'm not quite sure what should be in here exactly and how it should look. So consider this PR a request for feedback and I'll open it as a draft.