### PR TITLE
Hint the compiler that capacity is non-zero in mask_modulo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ extern crate alloc;
 #[macro_use]
 pub(crate) mod ringbuffer_trait;
 
+use core::num::NonZeroUsize;
+
 pub use ringbuffer_trait::RingBuffer;
 
 #[cfg(feature = "alloc")]
@@ -41,7 +43,13 @@ const fn mask(cap: usize, index: usize) -> usize {
 
 /// Used internally. Computes the bitmask used to properly wrap the ringbuffers.
 #[inline]
-const fn mask_modulo(cap: usize, index: usize) -> usize {
+fn mask_modulo(cap: usize, index: usize) -> usize {
+    index % unsafe { NonZeroUsize::new_unchecked(cap) }
+}
+
+/// Used internally. Computes the bitmask used to properly wrap the ringbuffers.
+#[inline]
+const fn const_mask_modulo(cap: usize, index: usize) -> usize {
     index % cap
 }
 

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -263,7 +263,7 @@ unsafe impl<T, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP
     fn push(&mut self, value: T) {
         if self.is_full() {
             let previous_value = mem::replace(
-                &mut self.buf[crate::mask_modulo(CAP, self.readptr)],
+                &mut self.buf[crate::const_mask_modulo(CAP, self.readptr)],
                 MaybeUninit::uninit(),
             );
             // make sure we drop whatever is being overwritten
@@ -275,7 +275,7 @@ unsafe impl<T, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP
             }
             self.readptr += 1;
         }
-        let index = crate::mask_modulo(CAP, self.writeptr);
+        let index = crate::const_mask_modulo(CAP, self.writeptr);
         self.buf[index] = MaybeUninit::new(value);
         self.writeptr += 1;
     }
@@ -284,7 +284,7 @@ unsafe impl<T, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP
         if self.is_empty() {
             None
         } else {
-            let index = crate::mask_modulo(CAP, self.readptr);
+            let index = crate::const_mask_modulo(CAP, self.readptr);
             let res = mem::replace(&mut self.buf[index], MaybeUninit::uninit());
             self.readptr += 1;
 
@@ -300,7 +300,7 @@ unsafe impl<T, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP
         get_unchecked_mut,
         readptr,
         writeptr,
-        crate::mask_modulo
+        crate::const_mask_modulo
     );
 
     #[inline]


### PR DESCRIPTION
This is an alternative to https://github.com/NULLx76/ringbuffer/pull/114. They are **not** compatible, sadly.

Modulo is faster for a non-zero divisor, so we can use the `NonZeroUsize` type to hint to the compiler that it can omit the case where the capacity is `0`. However, we can only do that in non-`const` context, so we need separate functions for the `ConstGenericRingBuffer` and `AllocRingBuffer`. Which led me to implement it like this:
```rust
// Not const: used by AllocRingBuffer<T, NonPowerOfTwo>
#[inline]
fn mask_modulo(cap: usize, index: usize) -> usize {
    index % unsafe { NonZeroUsize::new_unchecked(cap) }
}

// Const: used by ConstGenericRingBuffer
#[inline]
const fn const_mask_modulo(cap: usize, index: usize) -> usize {
    index % cap
}
```

This theoretically should only impact `AllocRingBuffer` for non powers of two. The `const_mask_modulo` should compile to the same assembly as before, but who knows what the compiler might do. The benchmarks are a bit too noisy to tell.

The improvements for alloc non power of two are significant, but less significant than https://github.com/NULLx76/ringbuffer/pull/114: it ranges from -10% to -30%. @jonay2000's more consistent benchmarks might help to determine the actual difference.

I'll leave it up to you what direction you want to go between this and #114 in (if any).