### PR TITLE
Fix importing RingBufferSize without alloc feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,3 +111,22 @@ jobs:
         with:
           command: build
           args: --target thumbv7em-none-eabihf --all-features
+
+  build-without-alloc:
+    name: Build no-std without alloc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install stable no-std toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target thumbv7em-none-eabihf --no-default-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,8 @@
 name: Rust
 
-on: [push]
+on:
+  pull_request:
+  push:
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/with_alloc/alloc_ringbuffer.rs
+++ b/src/with_alloc/alloc_ringbuffer.rs
@@ -104,7 +104,7 @@ unsafe impl<T: Send> Send for AllocRingBuffer<T> {}
 impl<T, const N: usize> From<[T; N]> for AllocRingBuffer<T, NonPowerOfTwo> {
     fn from(value: [T; N]) -> Self {
         let mut rb = Self::with_capacity_non_power_of_two(value.len());
-        rb.extend(value.into_iter());
+        rb.extend(value);
         rb
     }
 }
@@ -148,7 +148,7 @@ impl<T: Clone, const CAP: usize> From<&mut [T; CAP]> for AllocRingBuffer<T, NonP
 impl<T> From<alloc::vec::Vec<T>> for AllocRingBuffer<T, NonPowerOfTwo> {
     fn from(value: alloc::vec::Vec<T>) -> Self {
         let mut res = AllocRingBuffer::with_capacity_non_power_of_two(value.len());
-        res.extend(value.into_iter());
+        res.extend(value);
         res
     }
 }
@@ -156,7 +156,7 @@ impl<T> From<alloc::vec::Vec<T>> for AllocRingBuffer<T, NonPowerOfTwo> {
 impl<T> From<alloc::collections::VecDeque<T>> for AllocRingBuffer<T, NonPowerOfTwo> {
     fn from(value: alloc::collections::VecDeque<T>) -> Self {
         let mut res = AllocRingBuffer::with_capacity_non_power_of_two(value.len());
-        res.extend(value.into_iter());
+        res.extend(value);
         res
     }
 }
@@ -164,7 +164,7 @@ impl<T> From<alloc::collections::VecDeque<T>> for AllocRingBuffer<T, NonPowerOfT
 impl<T> From<alloc::collections::LinkedList<T>> for AllocRingBuffer<T, NonPowerOfTwo> {
     fn from(value: alloc::collections::LinkedList<T>) -> Self {
         let mut res = AllocRingBuffer::with_capacity_non_power_of_two(value.len());
-        res.extend(value.into_iter());
+        res.extend(value);
         res
     }
 }

--- a/src/with_alloc/vecdeque.rs
+++ b/src/with_alloc/vecdeque.rs
@@ -63,7 +63,7 @@ impl<T: Clone, const CAP: usize> From<&mut [T; CAP]> for GrowableAllocRingBuffer
 impl<T> From<alloc::vec::Vec<T>> for GrowableAllocRingBuffer<T> {
     fn from(value: alloc::vec::Vec<T>) -> Self {
         let mut res = GrowableAllocRingBuffer::new();
-        res.extend(value.into_iter());
+        res.extend(value);
         res
     }
 }
@@ -71,7 +71,7 @@ impl<T> From<alloc::vec::Vec<T>> for GrowableAllocRingBuffer<T> {
 impl<T> From<alloc::collections::LinkedList<T>> for GrowableAllocRingBuffer<T> {
     fn from(value: alloc::collections::LinkedList<T>) -> Self {
         let mut res = GrowableAllocRingBuffer::new();
-        res.extend(value.into_iter());
+        res.extend(value);
         res
     }
 }

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -1,10 +1,12 @@
 use crate::ringbuffer_trait::{RingBufferIntoIterator, RingBufferIterator, RingBufferMutIterator};
-use crate::with_alloc::alloc_ringbuffer::RingbufferSize;
 use crate::RingBuffer;
 use core::iter::FromIterator;
 use core::mem;
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
+
+#[cfg(feature = "alloc")]
+use crate::with_alloc::alloc_ringbuffer::RingbufferSize;
 
 /// The `ConstGenericRingBuffer` struct is a `RingBuffer` implementation which does not require `alloc` but
 /// uses const generics instead.


### PR DESCRIPTION
Fixes a failure to compile without the `alloc` feature enabled.
Also adds a Github action for building without the `alloc` feature.
