### PR TITLE
Increase copy speed by orders of magnitude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures"]
 license = "MIT"
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = { version = "0.4.0", features = ["html_reports"] }
 compiletest_rs = "0.10.0"
 
 [features]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,7 @@
-#![no_coverage]
+#![feature(coverage_attribute)]
+#![coverage(off)]
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
-use ringbuffer::{AllocRingBuffer, ConstGenericRingBuffer, RingBuffer};
+use ringbuffer::{AllocRingBuffer, ConstGenericRingBuffer, RingBuffer, SetLen};
 
 fn benchmark_push<T: RingBuffer<i32>, F: Fn() -> T>(b: &mut Bencher, new: F) {
     b.iter(|| {
@@ -63,6 +64,89 @@ fn benchmark_various<T: RingBuffer<i32>, F: Fn() -> T>(b: &mut Bencher, new: F) 
     })
 }
 
+fn benchmark_copy_to_slice_vs_extend<T: RingBuffer<i32>, F: Fn() -> T>(
+    rb_size: usize,
+    rb_type: &str,
+    fn_name: &str,
+    c: &mut Criterion,
+    new: F,
+) {
+    let mut group = c.benchmark_group(format!("{fn_name}({rb_type}, {rb_size})"));
+    let mut output = vec![0; rb_size];
+    group.bench_function(format!("CopyTo({rb_type}; {rb_size})"), |b| {
+        let mut rb = new();
+        rb.fill(9);
+        // making sure the read/write pointers wrap around
+        for _ in 0..rb_size / 2 {
+            let _ = rb.dequeue();
+            let _ = rb.enqueue(9);
+        }
+        b.iter(|| {
+            rb.copy_to_slice(0, &mut output);
+            assert_eq!(output[output.len() / 2], 9);
+            assert_eq!(output.len(), rb_size);
+        })
+    });
+    let mut output: Vec<i32> = Vec::with_capacity(rb_size);
+    group.bench_function(format!("ExtendVec({rb_type}; {rb_size})"), |b| {
+        let mut rb = new();
+        rb.fill(9);
+        // making sure the read/write pointers wrap around
+        for _ in 0..rb_size / 2 {
+            let _ = rb.dequeue();
+            let _ = rb.enqueue(9);
+        }
+        b.iter(|| {
+            unsafe { output.set_len(0) };
+            output.extend(rb.iter());
+            assert_eq!(output[output.len() / 2], 9);
+            assert_eq!(output.len(), rb_size);
+        })
+    });
+    group.finish();
+}
+
+fn benchmark_copy_from_slice_vs_extend<T: RingBuffer<i32> + SetLen, F: Fn() -> T>(
+    rb_size: usize,
+    rb_type: &str,
+    fn_name: &str,
+    c: &mut Criterion,
+    new: F,
+) {
+    let mut group = c.benchmark_group(format!("{fn_name}({rb_type}, {rb_size})"));
+    let input = vec![9; rb_size];
+    group.bench_function(format!("CopyFrom({rb_type}; {rb_size})"), |b| {
+        let mut rb = new();
+        rb.fill(0);
+        // making sure the read/write pointers wrap around
+        for _ in 0..rb_size / 2 {
+            let _ = rb.dequeue();
+            let _ = rb.enqueue(0);
+        }
+        for _ in 0..rb_size / 2 {}
+        b.iter(|| {
+            rb.copy_from_slice(0, &input);
+            assert_eq!(rb[rb.len() / 2], 9);
+            assert_eq!(rb.len(), rb_size);
+        })
+    });
+    group.bench_function(format!("ExtendRb({rb_type}; {rb_size})"), |b| {
+        let mut rb = new();
+        // making sure the read/write pointers wrap around
+        for _ in 0..rb_size / 2 {
+            let _ = rb.dequeue();
+            let _ = rb.enqueue(0);
+        }
+        b.iter(|| {
+            unsafe { rb.set_len(0) };
+            rb.extend(input.iter().copied());
+            assert_eq!(rb[rb.len() / 2], 9);
+            assert_eq!(rb.len(), rb_size);
+        })
+    });
+    group.finish();
+}
+
 macro_rules! generate_benches {
     (called, $c: tt, $rb: tt, $ty: tt, $fn: tt, $bmfunc: tt, $($i:tt),*) => {
         $(
@@ -84,6 +168,22 @@ macro_rules! generate_benches {
             $c.bench_function(&format!("{} {} 1M capacity {}", stringify!($rb), stringify!($bmfunc) ,stringify!($i)), |b| $bmfunc(b, || {
                 $rb::<$ty, $i>::$fn()
             }));
+        )*
+    };
+
+    (compare, $c: tt, $rb: tt, $ty: tt, $fn: tt, $bmfunc: tt, $($i:tt),*) => {
+        $(
+            $bmfunc($i, stringify!($rb), stringify!($bmfunc), $c, || {
+                $rb::<$ty>::$fn($i)
+            });
+        )*
+    };
+
+    (compare_typed, $c: tt, $rb: tt, $ty: tt, $fn: tt, $bmfunc: tt, $($i:tt),*) => {
+        $(
+            $bmfunc($i, stringify!($rb), stringify!($bmfunc), $c, || {
+                $rb::<$ty, $i>::$fn()
+            });
         )*
     };
 }
@@ -179,6 +279,119 @@ fn criterion_benchmark(c: &mut Criterion) {
         4096,
         8192,
         8195
+    ];
+    generate_benches![
+        compare,
+        c,
+        AllocRingBuffer,
+        i32,
+        new,
+        benchmark_copy_to_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
+    ];
+    generate_benches![
+        compare_typed,
+        c,
+        ConstGenericRingBuffer,
+        i32,
+        new,
+        benchmark_copy_to_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
+    ];
+    generate_benches![
+        compare,
+        c,
+        AllocRingBuffer,
+        i32,
+        new,
+        benchmark_copy_from_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
+    ];
+    generate_benches![
+        compare_typed,
+        c,
+        ConstGenericRingBuffer,
+        i32,
+        new,
+        benchmark_copy_from_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
+    ];
+
+    generate_benches![
+        compare,
+        c,
+        AllocRingBuffer,
+        i32,
+        new,
+        benchmark_copy_to_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
+    ];
+    generate_benches![
+        compare_typed,
+        c,
+        ConstGenericRingBuffer,
+        i32,
+        new,
+        benchmark_copy_to_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
+    ];
+    generate_benches![
+        compare,
+        c,
+        AllocRingBuffer,
+        i32,
+        new,
+        benchmark_copy_from_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
+    ];
+    generate_benches![
+        compare_typed,
+        c,
+        ConstGenericRingBuffer,
+        i32,
+        new,
+        benchmark_copy_from_slice_vs_extend,
+        16,
+        1024,
+        4096,
+        8192,
+        1_000_000,
+        1_048_576
     ];
 }
 

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -498,7 +498,7 @@ macro_rules! impl_ringbuffer {
 /// Implement various functions on implementors of [`RingBuffer`].
 /// This is to avoid duplicate code.
 macro_rules! impl_ringbuffer_ext {
-    ($get_unchecked: ident, $get_unchecked_mut: ident, $readptr: ident, $writeptr: ident, $mask: expr) => {
+    ($get_base_ptr: ident, $get_base_mut_ptr: ident, $get_unchecked: ident, $get_unchecked_mut: ident, $readptr: ident, $writeptr: ident, $mask: expr) => {
         #[inline]
         fn get_signed(&self, index: isize) -> Option<&T> {
             use core::ops::Not;
@@ -597,7 +597,7 @@ macro_rules! impl_ringbuffer_ext {
                 return;
             }
 
-            let base: *const T = $get_unchecked(rb, 0);
+            let base: *const T = $get_base_ptr(rb);
             let size = Self::ptr_buffer_size(rb);
             let offset_readptr = (*rb).$readptr + offset;
 
@@ -640,7 +640,7 @@ macro_rules! impl_ringbuffer_ext {
                 return;
             }
 
-            let base: *mut T = $get_unchecked_mut(rb, 0);
+            let base: *mut T = $get_base_mut_ptr(rb);
             let size = Self::ptr_buffer_size(rb);
             let offset_readptr = (*rb).$readptr + offset;
 

--- a/src/set_len_trait.rs
+++ b/src/set_len_trait.rs
@@ -1,0 +1,29 @@
+/// `SetLen` is a trait defining the unsafe `set_len` method
+/// on ringbuffers that support the operation.
+pub trait SetLen {
+    /// Force the length of the ringbuffer to `new_len`.
+    ///
+    /// Note that downsizing will not call Drop on elements at `new_len..old_len`,
+    /// potentially causing a memory leak.
+    ///
+    /// # Panics
+    /// Panics if `new_len` is greater than the ringbuffer capacity.
+    ///
+    /// # Safety
+    /// - Safe when `new_len <= old_len`.
+    /// - Safe when `new_len > old_len` and all the elements at `old_len..new_len` are already initialized.
+    unsafe fn set_len(&mut self, new_len: usize);
+}
+
+/// Implement `set_len` given a `readptr` and a `writeptr`.
+#[macro_export]
+macro_rules! impl_ring_buffer_set_len {
+    ($readptr: ident, $writeptr: ident) => {
+        #[inline]
+        unsafe fn set_len(&mut self, new_len: usize) {
+            let cap = self.capacity();
+            assert!(new_len <= cap, "Cannot set the a length of {new_len} on a ringbuffer with capacity for {cap} items");
+            self.$writeptr = self.$readptr + new_len;
+        }
+    };
+}

--- a/src/with_alloc/alloc_ringbuffer.rs
+++ b/src/with_alloc/alloc_ringbuffer.rs
@@ -274,6 +274,8 @@ unsafe impl<T> RingBuffer<T> for AllocRingBuffer<T> {
     }
 
     impl_ringbuffer_ext!(
+        get_base_ptr,
+        get_base_mut_ptr,
         get_unchecked,
         get_unchecked_mut,
         readptr,
@@ -330,6 +332,16 @@ impl<T> AllocRingBuffer<T> {
             writeptr: 0,
         }
     }
+}
+
+/// Get a const pointer to the buffer
+unsafe fn get_base_ptr<T>(rb: *const AllocRingBuffer<T>) -> *const T {
+    (*rb).buf.cast()
+}
+
+/// Get a mut pointer to the buffer
+unsafe fn get_base_mut_ptr<T>(rb: *mut AllocRingBuffer<T>) -> *mut T {
+    (*rb).buf
 }
 
 /// Get a reference from the buffer without checking it is initialized.

--- a/src/with_alloc/alloc_ringbuffer.rs
+++ b/src/with_alloc/alloc_ringbuffer.rs
@@ -7,7 +7,7 @@ use crate::ringbuffer_trait::{
 extern crate alloc;
 
 // We need boxes, so depend on alloc
-use crate::{mask_and, GrowableAllocRingBuffer};
+use crate::{impl_ring_buffer_set_len, mask_and, GrowableAllocRingBuffer, SetLen};
 use core::ptr;
 
 /// The `AllocRingBuffer` is a `RingBuffer` which is based on a Vec. This means it allocates at runtime
@@ -38,7 +38,7 @@ use core::ptr;
 /// ```
 #[derive(Debug)]
 pub struct AllocRingBuffer<T> {
-    buf: *mut T,
+    pub(crate) buf: *mut T,
 
     // the size of the allocation. Next power of 2 up from the capacity
     size: usize,
@@ -367,6 +367,10 @@ impl<T> IndexMut<usize> for AllocRingBuffer<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         self.get_mut(index).expect("index out of bounds")
     }
+}
+
+impl<T> SetLen for AllocRingBuffer<T> {
+    impl_ring_buffer_set_len!(readptr, writeptr);
 }
 
 #[cfg(test)]

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -356,7 +356,6 @@ impl<T, const CAP: usize> IndexMut<usize> for ConstGenericRingBuffer<T, CAP> {
     }
 }
 
-
 impl<T, const CAP: usize> SetLen for ConstGenericRingBuffer<T, CAP> {
     impl_ring_buffer_set_len!(readptr, writeptr);
 }

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -189,6 +189,16 @@ impl<T, const CAP: usize> ConstGenericRingBuffer<T, CAP> {
     }
 }
 
+/// Get a const pointer to the buffer
+unsafe fn get_base_ptr<T, const N: usize>(rb: *const ConstGenericRingBuffer<T, N>) -> *const T {
+    (*rb).buf.as_ptr().cast()
+}
+
+/// Get a mut pointer to the buffer
+unsafe fn get_base_mut_ptr<T, const N: usize>(rb: *mut ConstGenericRingBuffer<T, N>) -> *mut T {
+    (*rb).buf.as_mut_ptr().cast()
+}
+
 /// Get a reference from the buffer without checking it is initialized
 /// Caller MUST be sure this index is initialized, or undefined behavior will happen
 unsafe fn get_unchecked<'a, T, const N: usize>(
@@ -305,6 +315,8 @@ unsafe impl<T, const CAP: usize> RingBuffer<T> for ConstGenericRingBuffer<T, CAP
     }
 
     impl_ringbuffer_ext!(
+        get_base_ptr,
+        get_base_mut_ptr,
         get_unchecked,
         get_unchecked_mut,
         readptr,

--- a/src/with_const_generics.rs
+++ b/src/with_const_generics.rs
@@ -1,5 +1,5 @@
 use crate::ringbuffer_trait::{RingBufferIntoIterator, RingBufferIterator, RingBufferMutIterator};
-use crate::RingBuffer;
+use crate::{impl_ring_buffer_set_len, RingBuffer, SetLen};
 use core::iter::FromIterator;
 use core::mem::MaybeUninit;
 use core::mem::{self, ManuallyDrop};
@@ -35,7 +35,7 @@ use core::ops::{Index, IndexMut};
 /// ```
 #[derive(Debug)]
 pub struct ConstGenericRingBuffer<T, const CAP: usize> {
-    buf: [MaybeUninit<T>; CAP],
+    pub(crate) buf: [MaybeUninit<T>; CAP],
     readptr: usize,
     writeptr: usize,
 }
@@ -354,6 +354,11 @@ impl<T, const CAP: usize> IndexMut<usize> for ConstGenericRingBuffer<T, CAP> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         self.get_mut(index).expect("index out of bounds")
     }
+}
+
+
+impl<T, const CAP: usize> SetLen for ConstGenericRingBuffer<T, CAP> {
+    impl_ring_buffer_set_len!(readptr, writeptr);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Abstract

When `T` implements Copy, we can use the std/core method `copy_from_slice` to offload the data transfer to very optimized and potentially platform-specific functions.

## Backstory

I was troubleshooting some code that deals with a huge ringbuffer (1mln `f32`s), where the most common operation is copying the last 2 thousand elements.

After some profiling, I found that the slowest operation was just skipping and iterating over the elements that I needed to copy out of the buffer.

I experimented with the built-in `copy_from_slice`, which under the hood calls `memcpy`, and I got these results:

||baseline|memcpy|
|-|-|-|
|debug|~30ms|~5μs|
|release|~1ms|~2μs|

The baseline consists of using this:
```rust
let mut out = Vec::with_capacity(2000);
out.extend(ringbuffer.iter().skip(tons_of_items_to_skip).take(2000).copied());
```

While the code changes in this PR allow doing this:
```rust
let mut out = vec[0; 2000];
ringbuffer.copy_to_slice(tons_of_items_to_skip, &mut out); // one or two memcpy depending on the readptr position
```

The results are less impressive when working on the entire buffer, but still noticeable (benchmarks below).

## Proposed solution

I've added two methods: `copy_from_slice` and `copy_to_slice` to the RingBuffer trait.

## How it works

For ConstGeneric  and Alloc buffers, `copy_from_slice` works by taking the pointer to the first relevant byte of the ringbuffer. It then checks whether the `&slice` fits a contiguous region of memory. If it does, then a single copy operation is performed. If it doesn't, the copy is split into the two halves.

`copy_to_slice` works the same way but inverting the destination and source slices.

`VecDequeue` has a simpler (and safe) implementation based on the built-in methods `as_slices()`/`as_slices_mut()`.

## Benchmark

I've added some tests and run them with criterion. Here are some relevant results:

### `copy_to_slice` vs `extend` on a pre-allocated `Vec` with 1_000_000 elements

![image](https://github.com/user-attachments/assets/d7dcde1d-6cc4-46de-92bb-d5424305b576)
![image](https://github.com/user-attachments/assets/0faf01be-ab4b-4531-a012-7d643dc66ed6)


### `copy_to_slice` vs `extend` on a pre-allocated `Vec` with 16 elements

![image](https://github.com/user-attachments/assets/639df4ec-dca2-45f9-a1cb-49a92ae50ade)
![image](https://github.com/user-attachments/assets/720a0182-9c6b-4031-858d-9d7478497058)


I made sure to pre-allocate everything and, assuming I did it correctly, the speed-up looks quite substantial!

On this note, I added an unsafe `set_len` method to ConstGeneric and Alloc ring buffers that mimics what `Vec::set_len` does. It provides a nice way to "empty" a buffer of primitives by simply moving the buffer writeptr, without incurring the penalty of iterating over all the elements to call `Drop::drop`. Just like `Vec::set_len` this method can leak, as stated in the doc comment.