### PR TITLE
Implement nth and nth_back to provide a O(1) way of skipping through elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures"]
 license = "MIT"
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = { version = "0.4.0", features = ["html_reports"] }
 compiletest_rs = "0.10.0"
 
 [features]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,5 @@
-#![no_coverage]
+#![feature(coverage_attribute)]
+#![coverage(off)]
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use ringbuffer::{AllocRingBuffer, ConstGenericRingBuffer, RingBuffer};
 
@@ -60,6 +61,16 @@ fn benchmark_various<T: RingBuffer<i32>, F: Fn() -> T>(b: &mut Bencher, new: F) 
         }
 
         rb
+    })
+}
+
+fn benchmark_skip<T: RingBuffer<i32>, F: Fn() -> T>(b: &mut Bencher, new: F) {
+    let mut rb = new();
+    rb.fill(9);
+    b.iter(|| {
+        for i in 0..rb.len() {
+            assert_eq!(rb.iter().skip(i).next(), Some(&9));
+        }
     })
 }
 
@@ -173,6 +184,32 @@ fn criterion_benchmark(c: &mut Criterion) {
         i32,
         new,
         benchmark_various,
+        16,
+        17,
+        1024,
+        4096,
+        8192,
+        8195
+    ];
+    generate_benches![
+        typed,
+        c,
+        ConstGenericRingBuffer,
+        i32,
+        new,
+        benchmark_skip,
+        16,
+        1024,
+        4096,
+        8192
+    ];
+    generate_benches![
+        called,
+        c,
+        AllocRingBuffer,
+        i32,
+        new,
+        benchmark_skip,
         16,
         17,
         1024,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1449,4 +1449,61 @@ mod tests {
         test_clone!(GrowableAllocRingBuffer::<_>::new());
         test_clone!(AllocRingBuffer::<_>::new(4));
     }
+
+    #[test]
+    fn iter_nth_override() {
+        macro_rules! test_concrete {
+            ($rb_init: expr) => {
+                let rb = $rb_init([1, 2, 3, 4]);
+                assert_eq!(rb.iter().nth(0), Some(&1));
+                assert_eq!(rb.iter().nth(1), Some(&2));
+                assert_eq!(rb.iter().nth(2), Some(&3));
+                assert_eq!(rb.iter().nth(3), Some(&4));
+                assert_eq!(rb.iter().nth(4), None);
+
+                let mut rb = $rb_init([1, 2, 3, 4]);
+                assert_eq!(rb.iter_mut().nth(0), Some(&mut 1));
+                assert_eq!(rb.iter_mut().nth(1), Some(&mut 2));
+                assert_eq!(rb.iter_mut().nth(2), Some(&mut 3));
+                assert_eq!(rb.iter_mut().nth(3), Some(&mut 4));
+                assert_eq!(rb.iter_mut().nth(4), None);
+
+                let rb = $rb_init([1, 2, 3, 4]);
+                assert_eq!(rb.clone().into_iter().nth(0), Some(1));
+                assert_eq!(rb.clone().into_iter().nth(1), Some(2));
+                assert_eq!(rb.clone().into_iter().nth(2), Some(3));
+                assert_eq!(rb.clone().into_iter().nth(3), Some(4));
+                assert_eq!(rb.clone().into_iter().nth(4), None);
+            };
+        }
+
+        test_concrete!(|values: [i32; 4]| ConstGenericRingBuffer::<_, 4>::from(values));
+        test_concrete!(|values: [i32; 4]| GrowableAllocRingBuffer::<_>::from(values));
+        test_concrete!(|values: [i32; 4]| AllocRingBuffer::<_>::from(values));
+    }
+
+    #[test]
+    fn iter_nth_back_override() {
+        macro_rules! test_concrete {
+            ($rb_init: expr) => {
+                let rb = $rb_init([1, 2, 3, 4]);
+                assert_eq!(rb.iter().nth_back(0), Some(&4));
+                assert_eq!(rb.iter().nth_back(1), Some(&3));
+                assert_eq!(rb.iter().nth_back(2), Some(&2));
+                assert_eq!(rb.iter().nth_back(3), Some(&1));
+                assert_eq!(rb.iter().nth_back(4), None);
+
+                let mut rb = $rb_init([1, 2, 3, 4]);
+                assert_eq!(rb.iter_mut().nth_back(0), Some(&mut 4));
+                assert_eq!(rb.iter_mut().nth_back(1), Some(&mut 3));
+                assert_eq!(rb.iter_mut().nth_back(2), Some(&mut 2));
+                assert_eq!(rb.iter_mut().nth_back(3), Some(&mut 1));
+                assert_eq!(rb.iter_mut().nth_back(4), None);
+            };
+        }
+
+        test_concrete!(|values: [i32; 4]| ConstGenericRingBuffer::<_, 4>::from(values));
+        test_concrete!(|values: [i32; 4]| GrowableAllocRingBuffer::<_>::from(values));
+        test_concrete!(|values: [i32; 4]| AllocRingBuffer::<_>::from(values));
+    }
 }

--- a/src/ringbuffer_trait.rs
+++ b/src/ringbuffer_trait.rs
@@ -299,6 +299,11 @@ mod iter {
         fn size_hint(&self) -> (usize, Option<usize>) {
             (self.len, Some(self.len))
         }
+
+        fn nth(&mut self, n: usize) -> Option<Self::Item> {
+            self.index = (self.index + n).min(self.len);
+            self.next()
+        }
     }
 
     impl<'rb, T: 'rb, RB: RingBuffer<T>> FusedIterator for RingBufferIterator<'rb, T, RB> {}
@@ -315,6 +320,11 @@ mod iter {
             } else {
                 None
             }
+        }
+
+        fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+            self.len = self.len - n.min(self.len);
+            self.next_back()
         }
     }
 
@@ -358,6 +368,11 @@ mod iter {
                 None
             }
         }
+
+        fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+            self.len = self.len - n.min(self.len);
+            self.next_back()
+        }
     }
 
     impl<'rb, T, RB: RingBuffer<T> + 'rb> Iterator for RingBufferMutIterator<'rb, T, RB> {
@@ -376,6 +391,11 @@ mod iter {
 
         fn size_hint(&self) -> (usize, Option<usize>) {
             (self.len, Some(self.len))
+        }
+
+        fn nth(&mut self, n: usize) -> Option<Self::Item> {
+            self.index = (self.index + n).min(self.len);
+            self.next()
         }
     }
 


### PR DESCRIPTION
By providing an override for the default implementation of `nth` (and `nth_back`), which in turn is used by `skip`, there is a noticeable improvement in performance, as jumping through elements becomes a constant time operation.

The implementation applies only to `RingBufferIterator` and `RingBufferMutIterator`, as they don't drop skipped elements.

## Benchmarks

With 16 elements in the ringbuffer, criterion shows a 47% performance improvement

![image](https://github.com/user-attachments/assets/02858620-bd04-40a6-9a7b-fed1aea41d4c)


While with 1024 elements, criterion shows a 97% performance improvement

![image](https://github.com/user-attachments/assets/90bac273-4374-4ae1-b601-59b1cc85aa5d)